### PR TITLE
Add support for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 install:
   - make install
 script:
   make
-dist: xenial
-sudo: true
+
+matrix:
+  include:
+    # workaround for https://github.com/travis-ci/travis-ci/issues/9815
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
+    # black requires 3.6
+    - name: "Black formatting"
+      python: 3.6
+      install: pip install black
+      script: black --check testslide/ tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
   - "3.6"
   - "3.7"
 install:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: test
 
 .PHONY: black_check
 black_check:
-	if python -c 'import sys; sys.exit(1 if (sys.version_info.major == 3 and sys.version_info.minor <= 6) else 0)' ; then black --check testslide/ tests/ ; fi
+	if command -v black; then black --check testslide/ tests/ ; fi
 
 .PHONY: unittest_tests
 unittest_tests:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: test
 
 .PHONY: black_check
 black_check:
-	if python -c 'import sys ; sys.exit(1 if sys.version.startswith("2.") else 0)' ; then black --check testslide/ tests/ ; fi
+	if python -c 'import sys; sys.exit(1 if (sys.version_info.major == 3 and sys.version_info.minor <= 6) else 0)' ; then black --check testslide/ tests/ ; fi
 
 .PHONY: unittest_tests
 unittest_tests:

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,7 @@ setup(
         'mock ; python_version<"3"',
     ],
     extras_require = {
-        'test': [
-            'black ; python_version>="3.6"',
-        ],
         'build': [
-            'black ; python_version>="3.6"',
             "ipython",
             "sphinx",
             "sphinx-autobuild",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     extras_require = {
         'test': [
-            'black ; python_version>="3"',
+            'black ; python_version>="3.6"',
         ],
         'build': [
             "ipython",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "six",
         'typing ; python_version<"3"',
         'mock ; python_version<"3"',
+        'inspect2 ; python_version<"3.6"',
     ],
     extras_require = {
         'build': [

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
             'black ; python_version>="3.6"',
         ],
         'build': [
+            'black ; python_version>="3.6"',
             "ipython",
             "sphinx",
             "sphinx-autobuild",

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -3,21 +3,23 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-import re
-import sys
-import types
-import unittest
 from contextlib import contextmanager
+
 from typing import List  # noqa
+import sys
+import unittest
+import re
+import types
 
 import testslide.mock_callable
 import testslide.mock_constructor
-from testslide.strict_mock import StrictMock
 
-
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
+if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
     from contextlib import redirect_stdout, redirect_stderr
 else:
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -3,24 +3,21 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from contextlib import contextmanager
-
-from typing import List  # noqa
-import sys
-import unittest
 import re
+import sys
 import types
+import unittest
+from contextlib import contextmanager
+from typing import List  # noqa
 
 import testslide.mock_callable
 import testslide.mock_constructor
 from testslide.strict_mock import StrictMock
 
-if sys.version_info[0] >= 3:
+
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
     from contextlib import redirect_stdout, redirect_stderr
 else:
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -18,6 +18,7 @@ import types
 
 import testslide.mock_callable
 import testslide.mock_constructor
+from testslide.strict_mock import StrictMock  # noqa
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
     from contextlib import redirect_stdout, redirect_stderr

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -66,8 +66,8 @@ def _format_args(indent, *args, **kwargs):
     s += "{"
     if kwargs:
         s += "\n"
-        for k, v in kwargs.items():
-            s += "{}  {}={},\n".format(indentation, k, v)
+        for k in sorted(kwargs.keys()):
+            s += "{}  {}={},\n".format(indentation, k, kwargs[k])
         s += "{}".format(indentation)
     s += "}\n"
     return s

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
-import inspect
 import dis
 import copy
 import functools
@@ -18,6 +17,13 @@ if sys.version_info[0] >= 3:
     from unittest.mock import create_autospec, _must_skip
 else:
     from mock import create_autospec
+
+
+# inspect.signature kwarg 'wrapped' was introduced in 3.5
+if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+    import inspect
+else:
+    import inspect2 as inspect
 
 
 def _add_signature_validation(value, template, attr_name):


### PR DESCRIPTION
`contextlib.redirect_stderr/stdout` was introduced in python 3.4. This
change adds extra restrictions to the redirect_stderr/stdout
redefinitions as well as adds CI for testing on py34 and py35.

Also forces pip install of black for any python version less than 3.6,
as black is only officially supported on >= 3.6.