### PR TITLE
Implemented CallerInfoException to display additional info with Exception raises

### DIFF
--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -12,6 +12,7 @@ import sys
 import dis
 import copy
 import functools
+import inspect
 
 if sys.version_info[0] >= 3:
     from unittest.mock import create_autospec, _must_skip
@@ -187,6 +188,7 @@ class StrictMock(object):
         self.__dict__["__template"] = template
         self.__dict__["__runtime_attrs"] = runtime_attrs or []
         self.__dict__["__name"] = name
+        self.__dict__["__caller"] = inspect.getframeinfo(inspect.stack()[1][0])
 
         if (
             self.__template
@@ -323,8 +325,12 @@ class StrictMock(object):
             name = " name={}".format(repr(self.__dict__["__name"]))
         else:
             name = ""
-        return "<StrictMock 0x{:02X}{name}{template}>".format(
-            id(self), name=name, template=template
+        return "<StrictMock 0x{:02X}{name}{template} - {filename}:{lineno}>".format(
+            id(self),
+            name=name,
+            template=template,
+            filename=self.__dict__["__caller"].filename,
+            lineno=self.__dict__["__caller"].lineno,
         )
 
     def __get_copy(self):


### PR DESCRIPTION
Implemented CallerInfoException to display caller file name and line when exceptions are raised.

Also added a new assert assertRaisesWithRegexMessage so that we will be able to test the new message given that the string will begin with " .... {file_path}:{line no} ..."