### PR TITLE
Fail extra mock_callable() calls on the spot

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -248,6 +248,24 @@ def mock_callable_context(context):
                         self.callable_target(*self.call_args, **self.call_kwargs)
 
             @context.shared_context
+            def called_more_times_fail(context):
+                @context.example
+                def called_more_times(self):
+                    for _ in range(self.times):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+                    with self.assertRaisesWithMessage(
+                        UnexpectedCallReceived,
+                        (
+                            "{}, {}: Unexpected call received.\n"
+                            "  Expected to receive at most {} calls, "
+                            "but an extra call was made."
+                        ).format(
+                            repr(self.target_arg), repr(self.callable_arg), self.times
+                        ),
+                    ):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+
+            @context.shared_context
             def called_exactly_times(context):
                 @context.example
                 def called_exactly_times(self):
@@ -269,7 +287,7 @@ def mock_callable_context(context):
 
                         context.merge_context("not called")
                         context.merge_context("called less times")
-                        context.merge_context("called more times")
+                        context.merge_context("called more times fail")
 
                     @context.sub_context
                     def passes_when(context):
@@ -330,7 +348,7 @@ def mock_callable_context(context):
                         context.merge_context("assert failure")
 
                         context.merge_context("not called")
-                        context.merge_context("called more times")
+                        context.merge_context("called more times fail")
 
                     @context.sub_context
                     def passes_when(context):


### PR DESCRIPTION
Changes mock_callable() to also fail on the spot if an extra call is made, as opposed to only failing when the assertion is executed when the test finishes. This should make finding bugs easier, as the failure will point to the root of the issue directly.

Closes facebookincubator/TestSlide#3.