### PR TITLE
Allow and_assert_not_called() without behaivor.

### DIFF
--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -655,10 +655,31 @@ class _MockCallableDSL(object):
     def and_assert_called_exactly(self, count):
         """
         Assert that there were exactly the given number of calls.
+
+        If assertion is for 0 calls, any received call will raise
+        UnexpectedCallReceived and also an AssertionError.
         """
+        if count is 0:
+            if self._runner:
+                raise ValueError(
+                    "Asked to not accept any calls, but a behavior was previously defined."
+                )
+            self.to_raise(
+                UnexpectedCallReceived(
+                    ("{}, {}: Excepted not to be called!").format(
+                        _format_target(self._target), repr(self._method)
+                    )
+                )
+            )
         self._assert_runner()
         self._runner.add_exact_calls_assertion(count)
         return self
+
+    def and_assert_not_called(self):
+        """
+        Short for and_assert_called_exactly(0)
+        """
+        return self.and_assert_called_exactly(0)
 
     def and_assert_called_once(self):
         """
@@ -697,11 +718,3 @@ class _MockCallableDSL(object):
         Short for self.and_assert_called_at_least(1).
         """
         return self.and_assert_called_at_least(1)
-
-    def and_assert_not_called(self):
-        """
-        Disallow calls, by raising UnexpectedCallReceived.
-        """
-        self._assert_runner()
-        self._runner.add_exact_calls_assertion(0)
-        return self


### PR DESCRIPTION
Prior to this PR, `and_assert_not_called()` required a behavior to be defined, even though it should never run, eg:

```python
self.mock_callable('target', 'attr').to_return_value(None).and_assert_not_called()
```

With this PR, this will raise a `ValueError`, as it makes no sense. The new way of doing things will be:

```python
self.mock_callable('target', 'attr').and_assert_not_called()
```

Any call made will raise `UnexpectedCallReceived` **and** the `AssertionError` when the test finishes.

New tests were added to cover all those cases.

Closes #4 