### PR TITLE
Fix unpatching for alternative module names

### DIFF
--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -454,7 +454,7 @@ class _MockCallableDSL(object):
         else:
             self._target = target
 
-        target_method_id = (id(target), method)
+        target_method_id = (id(self._target), method)
 
         if target_method_id not in self.CALLABLE_MOCKS:
             if not callable_mock:


### PR DESCRIPTION
For [composition](https://testslide.readthedocs.io/en/1.4.2/mock_callable/index.html#composition) to work with `mock_callable()`, it needs to keep tabs on the target being mocked. It uses the `id()` of the target for that, but for cases where modules are given as strings, potentially with different names, the string was wrongly being used as the id, and not the module itself. For this case, unpatching is broken.

This PR fixes that, and adds a test case to cover the scenario.