### PR TITLE
Drop usage of inspect2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
 install:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "six",
         'typing ; python_version<"3"',
         'mock ; python_version<"3"',
-        'inspect2 ; python_version<"3.6"',
     ],
     extras_require = {
         'build': [

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -20,13 +20,6 @@ else:
     from mock import create_autospec
 
 
-# inspect.signature kwarg 'wrapped' was introduced in 3.5
-if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
-    import inspect
-else:
-    import inspect2 as inspect
-
-
 def _add_signature_validation(value, template, attr_name):
     if sys.version_info[0] == 2:
         return value


### PR DESCRIPTION
There's no hard need to require inspect2, let's drop this requirement.