### PR TITLE
Allow and_assert_called_exactly(0) with behavior.

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -381,16 +381,6 @@ def mock_callable_context(context):
                         for _ in range(self.times + 1):
                             self.callable_target(*self.call_args, **self.call_kwargs)
 
-            @context.sub_context(".and_assert_not_called()")
-            def and_assert_not_called(context):
-                @context.example
-                def can_not_use_with_previously_existing_behavior(self):
-                    with self.assertRaisesWithMessage(
-                        ValueError,
-                        "Asked to not accept any calls, but a behavior was previously defined.",
-                    ):
-                        self.mock_callable_dsl.and_assert_not_called()
-
         @context.sub_context
         def default_behavior(context):
             @context.example

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -660,10 +660,6 @@ class _MockCallableDSL(object):
         UnexpectedCallReceived and also an AssertionError.
         """
         if count is 0:
-            if self._runner:
-                raise ValueError(
-                    "Asked to not accept any calls, but a behavior was previously defined."
-                )
             self.to_raise(
                 UnexpectedCallReceived(
                     ("{}, {}: Excepted not to be called!").format(


### PR DESCRIPTION
It seems that the idiom of doing:

```python
self.mock_callable(target, "attr").to_return_value(whatever).and_assert_called_exactly(calls)
```

where `calls` is defined externally (eg: as a function argument) is too common. Currently, this raises `ValueError` when `calls` is zero, which forces this to be written as:

```python
mc = self.mock_callable(target, "attr")
if calls:
  mc.to_return_value(whatever)
mc.and_assert_called_exactly(calls)
```

This defeats the fluidity of the DSL, so let's not enforce it.

This still case, is kept the same:

```python
self.mock_callable(target, "attr").and_assert_called_exactly(0)
```
