### PR TITLE
Fix and_assert_not_called() with existing behavior

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -381,6 +381,12 @@ def mock_callable_context(context):
                         for _ in range(self.times + 1):
                             self.callable_target(*self.call_args, **self.call_kwargs)
 
+            @context.sub_context(".and_assert_not_called()")
+            def and_assert_not_called(context):
+                @context.example
+                def can_use_with_previously_existing_behavior(self):
+                    self.mock_callable_dsl.and_assert_not_called()
+
         @context.sub_context
         def default_behavior(context):
             @context.example

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -660,6 +660,7 @@ class _MockCallableDSL(object):
         UnexpectedCallReceived and also an AssertionError.
         """
         if count is 0:
+            self._runner = None
             self.to_raise(
                 UnexpectedCallReceived(
                     ("{}, {}: Excepted not to be called!").format(


### PR DESCRIPTION
This:

```python
self.mock_callable("target", "attr").to_return_value(None).and_assert_not_called()
```

Should work, but is failing with `ValueError`.

This PR fixes that, and adds at test to cover this use case.