### PR TITLE
Fix mock_* assertions with DSL

### DIFF
--- a/docs/testslide_dsl/context_hooks/index.rst
+++ b/docs/testslide_dsl/context_hooks/index.rst
@@ -96,7 +96,7 @@ You can also define after hooks from within examples:
     do_first_thing()
 
     @self.after
-    def run_after_example_finishes():
+    def run_after_example_finishes(self):
       do_something_after_last_thing()
 
     do_last_thing()

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -779,7 +779,7 @@ class TestDSLMergeTestCase(TestDSLBase):
                     calls.append("example")
                     raise SimulatedFailure("Simulated failure", "(extra)")
 
-            with self.assertRaises(AggregatedExceptions):
+            with self.assertRaises(SimulatedFailure):
                 self.run_first_context_first_example()
 
             self.assertEqual(
@@ -1083,7 +1083,7 @@ class TestDSLBeforeHook(TestDSLBase):
 
         try:
             self.run_first_context_first_example()
-        except AggregatedExceptions:
+        except SimulatedFailure:
             pass
         self.assertEqual(mock.mock_calls, [call("first before"), call("second before")])
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -268,9 +268,6 @@ class Example(object):
         for after in reversed(after_functions):
             with aggregated_exceptions.catch():
                 after(context_data)
-        for assertion in self.context.assertions:
-            with aggregated_exceptions.catch():
-                assertion()
         if aggregated_exceptions.exceptions:
             aggregated_exceptions.raise_correct_exception()
 
@@ -377,18 +374,22 @@ class Context(object):
         def _mock_callable(self, *args, **kwargs):
             return testslide.mock_callable.mock_callable(*args, **kwargs)
 
-        self.add_function("mock_callable", _mock_callable)
+        self.add_function("mock_callable", _mock_callable, skip_if_exists=True)
 
-        def register_assertion(assertion):
-            self.assertions.append(assertion)
+        def set_register_assertion(context_data, example):
+            def register_assertion(assertion):
+                self.after_functions.insert(0, lambda _: assertion())
 
-        testslide.mock_callable.register_assertion = register_assertion
+            testslide.mock_callable.register_assertion = register_assertion
+            example()
+
+        self.around_functions.append(set_register_assertion)
 
     def _setup_mock_constructor(self):
         def _mock_constructor(self, *args, **kwargs):
             return testslide.mock_constructor.mock_constructor(*args, **kwargs)
 
-        self.add_function("mock_constructor", _mock_constructor)
+        self.add_function("mock_constructor", _mock_constructor, skip_if_exists=True)
 
     # Constructor
 
@@ -415,7 +416,6 @@ class Context(object):
         self.examples = []
         self.before_functions = []
         self.after_functions = []
-        self.assertions = []
         self.around_functions = []
         self.context_data_methods = {}
         self.context_data_memoizable_attributes = {}
@@ -425,8 +425,9 @@ class Context(object):
         if not self.parent_context and not self.shared:
             self.all_top_level_contexts.append(self)
 
-        self._setup_mock_callable()
-        self._setup_mock_constructor()
+        if not self.parent_context:
+            self._setup_mock_callable()
+            self._setup_mock_constructor()
 
     # Properties
 
@@ -606,11 +607,11 @@ class Context(object):
             ]
         )
 
-    def add_function(self, name, function_code):
+    def add_function(self, name, function_code, skip_if_exists=False):
         """
         Add given function to example execution scope.
         """
-        if self._context_data_has_attr(name):
+        if not skip_if_exists and self._context_data_has_attr(name):
             raise AttributeError(
                 'Attribute "{}" already set for context "{}"'.format(name, self)
             )

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -183,7 +183,10 @@ class AggregatedExceptions(Exception):
         ex_types = {type(ex) for ex in self.exceptions}
         if Skip in ex_types or unittest.SkipTest in ex_types:
             raise Skip()
+        elif len(self.exceptions) == 1:
+            raise self.exceptions[0]
         else:
+            raise self
             if len(self.exceptions) == 1:
                 raise self.exceptions[0]
             else:

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -184,7 +184,10 @@ class AggregatedExceptions(Exception):
         if Skip in ex_types or unittest.SkipTest in ex_types:
             raise Skip()
         else:
-            raise self
+            if len(self.exceptions) == 1:
+                raise self.exceptions[0]
+            else:
+                raise self
 
 
 class Skip(Exception):

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -275,6 +275,7 @@ class Example(object):
         """
         Run example, including all hooks.
         """
+        _run_before_once_hooks()
         if not around_functions:
             self._example_runner(context_data)
             return
@@ -292,7 +293,6 @@ class Example(object):
         try:
             if self.skip:
                 raise Skip()
-            _run_before_once_hooks()
             context_data = _ContextData(self.context)
             with _add_traceback_context_manager():
                 self._run_example(


### PR DESCRIPTION
Assertions for `mock_callable()` / `mock_constructor()` are not working as expected for all cases when using the DSL.

Due to an implementation bug, assertions are executed for the last context declared, not the context that was actually executed. Tests were passing, because they were not exercising this more complex scenario. Integration with Python`s Unittest is not affected.

This PR adds test coverage for the DSL +  `mock_callable()` / `mock_constructor()` integration, that fails without the fixes here.