### PR TITLE
Fix assertion on call limit

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -257,9 +257,10 @@ def mock_callable_context(context):
                     with self.assertRaisesWithMessage(
                         UnexpectedCallReceived,
                         (
-                            "{}, {}: Unexpected call received.\n"
-                            "  Expected to receive at most {} calls, "
-                            "but an extra call was made."
+                            "Unexpected call received.\n"
+                            "{}, {}:\n"
+                            "  expected to receive at most {} calls with any arguments "
+                            "  but received an extra call."
                         ).format(
                             repr(self.target_arg), repr(self.callable_arg), self.times
                         ),

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -116,9 +116,16 @@ class _Runner(object):
         if self.max_calls and self.call_count > self.max_calls:
             raise UnexpectedCallReceived(
                 (
-                    "{}, {}: Unexpected call received.\n"
-                    "  Expected to receive at most {} calls, but an extra call was made."
-                ).format(_format_target(self.target), repr(self.method), self.max_calls)
+                    "Unexpected call received.\n"
+                    "{}, {}:\n"
+                    "  expected to receive at most {} calls with {}"
+                    "  but received an extra call."
+                ).format(
+                    _format_target(self.target),
+                    repr(self.method),
+                    self.max_calls,
+                    self._args_message(),
+                )
             )
 
     def add_accepted_args(self, *args, **kwargs):
@@ -659,8 +666,7 @@ class _MockCallableDSL(object):
         If assertion is for 0 calls, any received call will raise
         UnexpectedCallReceived and also an AssertionError.
         """
-        if not count:
-            self._runner = None
+        if not self._runner:
             self.to_raise(
                 UnexpectedCallReceived(
                     ("{}, {}: Excepted not to be called!").format(
@@ -668,7 +674,6 @@ class _MockCallableDSL(object):
                     )
                 )
             )
-        self._assert_runner()
         self._runner.add_exact_calls_assertion(count)
         return self
 


### PR DESCRIPTION
A regression was recently introduced, that broke `.and_assert_not_called()` when you have mock_callable setup for different call arguments such as:

```python
self.mock_callable(target, 'attr').to_return_value(None)
self.mock_callable(target, 'attr').for_call(1, 2).and_assert_not_called()
```

Previously, this would break:

```python
target.attr("other", "arguments")
```

but it must pass. This PR fixes that.