### PR TITLE
Fix mock_constructor() and with_wrapper()

### DIFF
--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -14,10 +14,15 @@ import contextlib
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 
 
-class Target(object):  # noqa
+class BaseTarget(object):
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
+
+
+class Target(BaseTarget):  # noqa
+    def __init__(self, *args, **kwargs):
+        super(Target, self).__init__(*args, **kwargs)
 
 
 original_target_class = Target

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -97,15 +97,17 @@ def mock_constructor(context):
         # We use a wrapper here to validate that the first argument of __new__ is not
         # passed along
         def wrapper(original_callable, *args, **kwargs):
-            self.assertEqual(args, mock_args)
-            self.assertEqual(kwargs, mock_kwargs)
+            instance = original_callable(*args, **kwargs)
+            self.assertTrue(type(instance), original_target_class)
+            self.assertEqual(instance.args, mock_args)
+            self.assertEqual(instance.kwargs, mock_kwargs)
             return "mocked"
 
         self.mock_constructor(self.target_module, target_class_name).for_call(
             *mock_args, **mock_kwargs
         ).with_wrapper(wrapper)
 
-        # And get a reference to the pached class
+        # And get a reference to the patched class
         target_class = getattr(self.target_module, target_class_name)
 
         # Generic calls works (to_call_original)

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -441,13 +441,13 @@ class _MockCallableDSL(object):
         method,
         callable_mock=None,
         original_callable=None,
-        prepend_first_arg=None,
+        extra_first_arg=None,
     ):
         self._original_target = target
         self._method = method
         self._runner = None
         self._next_runner_accepted_args = None
-        self.prepend_first_arg = prepend_first_arg
+        self.extra_first_arg = extra_first_arg
 
         if isinstance(target, six.string_types):
             self._target = testslide._importer(target)
@@ -510,8 +510,8 @@ class _MockCallableDSL(object):
         """
         Filter for only calls like this.
         """
-        if self.prepend_first_arg:
-            args = (self.prepend_first_arg,) + args
+        if self.extra_first_arg:
+            args = (self.extra_first_arg,) + args
         if self._runner:
             self._runner.add_accepted_args(*args, **kwargs)
         else:
@@ -619,12 +619,16 @@ class _MockCallableDSL(object):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if self.prepend_first_arg and args:
+            if self.extra_first_arg and args:
                 assert (
-                    args[0] == self.prepend_first_arg
+                    args[0] == self.extra_first_arg
                 ), "Received unexpected first argument: {}.".format(args[0])
                 args = args[1:]
-            return func(self._original_callable, *args, **kwargs)
+                return func(
+                    self._original_callable, self.extra_first_arg, *args, **kwargs
+                )
+            else:
+                return func(self._original_callable, *args, **kwargs)
 
         self._add_runner(
             _ImplementationRunner(

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -11,10 +11,6 @@ from __future__ import unicode_literals
 import inspect
 import six
 
-if six.PY2:
-    from mock import ANY
-else:
-    from unittest.mock import ANY
 import testslide
 from testslide.mock_callable import _MockCallableDSL, _CallableMock
 
@@ -90,5 +86,5 @@ def mock_constructor(target, class_name):
         "__new__",
         callable_mock=callable_mock,
         original_callable=original_callable,
-        prepend_first_arg=ANY,
+        extra_first_arg=mocked_class,
     )


### PR DESCRIPTION
This PR fixes 2 stacked bugs:

- `with_wrapper()` was failing with `TypeError: original_callable() takes at least 1 argument (0 given)`.
- Once this was fixed, it exposed a tricky underlying bug, that would make it raise `TypeError: super(type, obj): obj must be an instance or subtype of type`. This happened exclusively when `__init__` of the mocked class called `super(SomeClass, self)`. In this case, `type(self)` would be `SomeClass` (the original) and `SomeClass` would resolve to `SomeClassMock` (that `mock_constructor()` puts there), making `super()` rightfully blow up.

Closes facebookincubator/TestSlide/issues#15.