### PR TITLE
Refactor mock_constructor to better support all mocking features

### DIFF
--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -12,6 +12,7 @@ import sys
 import contextlib
 
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
+from testslide.mock_callable import _MockCallableDSL
 
 
 class Target(object):  # noqa
@@ -78,11 +79,28 @@ def mock_constructor(context):
             with self.assertRaisesWithMessage(ValueError, "Target must be a class."):
                 self.mock_constructor(self.target_module, "dummy")
 
+    @context.sub_context
+    def supports_wrapping(context):
+        def wrapper(original_callable, *args, **kwargs):
+            args = reversed(args)
+            return original_callable(*args, **kwargs)
+
+        @context.before
+        def wrap(self):
+            self.mock_constructor(self.target_module, target_class_name).for_call(
+                "Hello", "World"
+            ).with_wrapper(wrapper).and_assert_called_once()
+
+        @context.example
+        def constructor_is_wrapped(self):
+            target = Target("Hello", "World")
+            self.assertSequenceEqual(target.args, ("World", "Hello"))
+
     @context.example
     def it_uses_mock_callable_dsl(self):
-        self.assertEqual(
-            type(self.mock_constructor(self.target_module, target_class_name)),
-            type(self.mock_callable(self.target_module, "dummy")),
+        self.assertIsInstance(
+            self.mock_constructor(self.target_module, target_class_name),
+            _MockCallableDSL,
         )
 
     @context.example

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -97,6 +97,18 @@ def mock_constructor(context):
             self.assertSequenceEqual(target.args, ("World", "Hello"))
 
     @context.example
+    def registers_call_count_and_args_correctly(self):
+        self.mock_constructor(self.target_module, target_class_name).for_call(
+            "Hello", "World"
+        ).to_return_value(None).and_assert_called_exactly(2)
+
+        t1 = Target("Hello", "World")
+        t2 = Target("Hello", "World")
+
+        self.assertIsNone(t1)
+        self.assertIsNone(t2)
+
+    @context.example
     def it_uses_mock_callable_dsl(self):
         self.assertIsInstance(
             self.mock_constructor(self.target_module, target_class_name),

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -108,12 +108,28 @@ class _Runner(object):
         self.method = method
         self.original_callable = original_callable
         self.accepted_args = None
-        self.call_count = 0
-        self.max_calls = None
+
+        self._call_count = 0
+        self._max_calls = None
 
     def run(self, *args, **kwargs):
-        self.call_count += 1
-        if self.max_calls and self.call_count > self.max_calls:
+        self.inc_call_count()
+
+    @property
+    def call_count(self):
+        return self._call_count
+
+    @property
+    def max_calls(self):
+        return self._max_calls
+
+    def _set_max_calls(self, times):
+        if not self._max_calls or times < self._max_calls:
+            self._max_calls = times
+
+    def inc_call_count(self):
+        self._call_count += 1
+        if self.max_calls and self._call_count > self.max_calls:
             raise UnexpectedCallReceived(
                 (
                     "{}, {}: Unexpected call received.\n"
@@ -140,10 +156,6 @@ class _Runner(object):
             )
         else:
             return "any arguments "
-
-    def _set_max_calls(self, times):
-        if not self.max_calls or (self.max_calls and times < self.max_calls):
-            self.max_calls = times
 
     def add_exact_calls_assertion(self, times):
         self._set_max_calls(times)

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -435,19 +435,11 @@ class _MockCallableDSL(object):
 
     CALLABLE_MOCKS = {}  # NOQA T484
 
-    def __init__(
-        self,
-        target,
-        method,
-        callable_mock=None,
-        original_callable=None,
-        prepend_first_arg=None,
-    ):
+    def __init__(self, target, method, callable_mock=None, original_callable=None):
         self._original_target = target
         self._method = method
         self._runner = None
         self._next_runner_accepted_args = None
-        self.prepend_first_arg = prepend_first_arg
 
         if isinstance(target, six.string_types):
             self._target = testslide._importer(target)
@@ -510,8 +502,6 @@ class _MockCallableDSL(object):
         """
         Filter for only calls like this.
         """
-        if self.prepend_first_arg:
-            args = (self.prepend_first_arg,) + args
         if self._runner:
             self._runner.add_accepted_args(*args, **kwargs)
         else:
@@ -619,11 +609,6 @@ class _MockCallableDSL(object):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if self.prepend_first_arg and args:
-                assert (
-                    args[0] == self.prepend_first_arg
-                ), "Received unexpected first argument: {}.".format(args[0])
-                args = args[1:]
             return func(self._original_callable, *args, **kwargs)
 
         self._add_runner(

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -11,12 +11,8 @@ from __future__ import unicode_literals
 import inspect
 import six
 
-if six.PY2:
-    from mock import ANY
-else:
-    from unittest.mock import ANY
 import testslide
-from testslide.mock_callable import _MockCallableDSL, _CallableMock
+from testslide.mock_callable import _MockCallableDSL, _CallableMock, _Runner
 
 _unpatchers = []  # type: List[Callable]  # noqa T484
 
@@ -44,6 +40,58 @@ def _is_string(obj):
     )
 
 
+def is_cls_mock(cls):
+    return getattr(cls, "__mock", False) == True
+
+
+class _ConstructorRunner(_Runner):
+    def __init__(self, parent_runner):
+        # Must come before super constructor or call_count setter will fail
+        # due to uninitialized parent.
+        self.parent = parent_runner
+
+        super(_ConstructorRunner, self).__init__(
+            target=parent_runner.target,
+            method="__new__",
+            original_callable=parent_runner.original_callable,
+        )
+
+    @property
+    def call_count(self):
+        return self.parent.call_count
+
+    @call_count.setter
+    def call_count(self, times):
+        self.parent.call_count = times
+
+    def _set_max_calls(self, times):
+        return self.parent._set_max_calls(times)
+
+    def add_accepted_args(self, *args, **kwargs):
+        return self.parent.add_accepted_args(*args, **kwargs)
+
+    def can_accept_args(self, *args, **kwargs):
+        if not args or not is_cls_mock(args[0]):
+            return False
+
+        return self.parent.can_accept_args(*args[1:], **kwargs)
+
+    def run(self, target_cls, *args, **kwargs):
+        assert is_cls_mock(
+            target_cls
+        ), "ConstructorRunner called for non-mock class: {}".format(target_cls)
+
+        return self.parent.run(*args, **kwargs)
+
+
+class _MockConstructorDSL(_MockCallableDSL):
+    """Specialized version of _MockCallableDSL to call __new__ with correct args"""
+
+    def _add_runner(self, runner):
+        wrapped_runner = _ConstructorRunner(runner)
+        return super(_MockConstructorDSL, self)._add_runner(wrapped_runner)
+
+
 def mock_constructor(target, class_name):
     if not _is_string(class_name):
         raise ValueError("Second argument must be a string with the name of the class.")
@@ -61,7 +109,6 @@ def mock_constructor(target, class_name):
             )
         callable_mock = mocked_class.__new__
     else:
-
         original_class = getattr(target, class_name)
         if not inspect.isclass(original_class):
             raise ValueError("Target must be a class.")
@@ -77,18 +124,16 @@ def mock_constructor(target, class_name):
         mocked_class = type(
             str(original_class.__name__ + "Mock"),
             (original_class,),
-            {"__new__": callable_mock},
+            {"__new__": callable_mock, "__mock": True},
         )
+        mocked_class.__mock = True
+
         setattr(target, class_name, mocked_class)
         _mocked_classes[mocked_class_id] = (original_class, mocked_class)
 
-    def original_callable(_, *args, **kwargs):
-        return original_class(*args, **kwargs)
-
-    return _MockCallableDSL(
+    return _MockConstructorDSL(
         mocked_class,
         "__new__",
         callable_mock=callable_mock,
-        original_callable=original_callable,
-        prepend_first_arg=ANY,
+        original_callable=original_class,
     )

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -46,26 +46,20 @@ def is_cls_mock(cls):
 
 class _ConstructorRunner(_Runner):
     def __init__(self, parent_runner):
-        # Must come before super constructor or call_count setter will fail
-        # due to uninitialized parent.
-        self.parent = parent_runner
-
         super(_ConstructorRunner, self).__init__(
             target=parent_runner.target,
             method="__new__",
             original_callable=parent_runner.original_callable,
         )
 
+        self.parent = parent_runner
+
     @property
     def call_count(self):
         return self.parent.call_count
 
-    @call_count.setter
-    def call_count(self, times):
-        self.parent.call_count = times
-
     def _set_max_calls(self, times):
-        return self.parent._set_max_calls(times)
+        self.parent._set_max_calls(times)
 
     def add_accepted_args(self, *args, **kwargs):
         return self.parent.add_accepted_args(*args, **kwargs)


### PR DESCRIPTION
Previously mock_constructor simply created a regular mock for the
__new__ method of its target. Unfortunately that causes issues when
using more complex mocking features, since users expect to pass
arguments as they would to constructor (without the class as the first
argument).

To fix that:

- Introduce _ConstructorRunner, which can wrap any other runner for Mock
  actions while ensuring the initial class argument is not passed on,
  and corresponds to a mock class generated by TestSlide.
- Introduce _MockConstructorDSL, wrapping methods which need special
  accounting for constructor arguments, and ensuring all runners are
  wrapped by a _ConstructorRunner

Fixes: #15