### PR TITLE
Fix mock_constructor() patching

### DIFF
--- a/docs/mock_constructor/index.rst
+++ b/docs/mock_constructor/index.rst
@@ -70,7 +70,7 @@ mock_constructor is a way to not only solve this for Python 3, but also provide 
 Internally, mock_constructor will:
 
 * Patch the class at its module with a subclass of it, that is dynamically created.
-* ``__new__`` of this dynamic subclass is handled by mock_callable.
+* This new subclass is essentially a copy of the original class, but overrides its ``__new__`` with a factory that handles `mock_constructor()` interface.
 
 Integration With Other Frameworks
 ---------------------------------

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -44,9 +44,10 @@ def dummy():
 def mock_constructor(context):
 
     context.memoize("target_module", lambda self: sys.modules[__name__])
-    context.memoize(
-        "target_class", lambda self: getattr(self.target_module, target_class_name)
-    )
+
+    @context.function
+    def get_target_class(self):
+        return getattr(self.target_module, target_class_name)
 
     @context.function
     @contextlib.contextmanager
@@ -66,7 +67,7 @@ def mock_constructor(context):
     @context.before
     def assert_unpatched(self):
         self.assertTrue(
-            original_target_class is self.target_class, "Unpatching didn't work."
+            original_target_class is self.get_target_class(), "Unpatching didn't work."
         )
         args = (1, 2)
         kwargs = {"3": 4, "5": 6}
@@ -76,7 +77,7 @@ def mock_constructor(context):
         self.assertEqual(t.kwargs, kwargs)
 
     @context.sub_context
-    def argument_validation(context):
+    def arguments(context):
         @context.example
         def rejects_non_string_class_name(self):
             with self.assertRaisesWithMessage(
@@ -90,37 +91,6 @@ def mock_constructor(context):
             with self.assertRaisesWithMessage(ValueError, "Target must be a class."):
                 self.mock_constructor(self.target_module, "dummy")
 
-    @context.sub_context
-    def supports_wrapping(context):
-        @context.before
-        def wrap(self):
-            def wrapper(original_callable, *args, **kwargs):
-                args = reversed(args)
-                instance = original_callable(*args, **kwargs)
-                return instance
-
-            self.mock_constructor(self.target_module, target_class_name).for_call(
-                "Hello", "World"
-            ).with_wrapper(wrapper).and_assert_called_once()
-
-        @context.example
-        def constructor_is_wrapped(self):
-            target_class = getattr(self.target_module, target_class_name)
-            target = target_class("Hello", "World")
-            self.assertSequenceEqual(target.args, ("World", "Hello"))
-
-    @context.example
-    def registers_call_count_and_args_correctly(self):
-        self.mock_constructor(self.target_module, target_class_name).for_call(
-            "Hello", "World"
-        ).to_return_value(None).and_assert_called_exactly(2)
-
-        t1 = Target("Hello", "World")
-        t2 = Target("Hello", "World")
-
-        self.assertIsNone(t1)
-        self.assertIsNone(t2)
-
     @context.example
     def it_uses_mock_callable_dsl(self):
         self.assertIsInstance(
@@ -128,53 +98,86 @@ def mock_constructor(context):
             _MockCallableDSL,
         )
 
-    @context.example
-    def mocking_works(self):
+    @context.sub_context("mock_callable() integration")
+    def mock_callable_integration(context):
+        @context.sub_context
+        def assertions(context):
+            @context.example
+            def registers_call_count_and_args_correctly(self):
+                self.mock_constructor(self.target_module, target_class_name).for_call(
+                    "Hello", "World"
+                ).to_return_value(None).and_assert_called_exactly(2)
 
-        # Allow all other calls
-        self.mock_constructor(self.target_module, target_class_name).to_call_original()
-        # Mock specefic call
-        mock_args = (6, 7)
-        mock_kwargs = {"8": 9, "10": 11}
+                target_class = self.get_target_class()
+                t1 = target_class("Hello", "World")
+                t2 = target_class("Hello", "World")
 
-        # We use a wrapper here to validate that the first argument of __new__ is not
-        # passed along
-        def wrapper(original_callable, *args, **kwargs):
-            instance = original_callable(*args, **kwargs)
-            # self.assertTrue(type(instance), original_target_class)
-            self.assertEqual(instance.args, mock_args)
-            self.assertEqual(instance.kwargs, mock_kwargs)
-            self.assertEqual(instance.calls_super(), "from super")
-            self.assertEqual(args, mock_args)
-            self.assertEqual(kwargs, mock_kwargs)
-            return "mocked"
+                self.assertIsNone(t1)
+                self.assertIsNone(t2)
 
-        self.mock_constructor(self.target_module, target_class_name).for_call(
-            *mock_args, **mock_kwargs
-        ).with_wrapper(wrapper)
+        @context.example
+        def accepts_module_as_string(self):
+            args = (6, 7)
+            kwargs = {"8": 9, "10": 11}
+            self.mock_constructor(
+                self.target_module.__name__, target_class_name
+            ).for_call(*args, **kwargs).to_return_value("mocked")
+            mocked_instance = self.get_target_class()(*args, **kwargs)
+            self.assertEqual(mocked_instance, "mocked")
 
-        # And get a reference to the pached class
-        target_class = getattr(self.target_module, target_class_name)
+        @context.sub_context
+        def behavior(context):
+            @context.sub_context(".with_wrapper()")
+            def with_wrapper(context):
+                @context.before
+                def setup_wrapper(self):
+                    self.mock_constructor(
+                        self.target_module, target_class_name
+                    ).to_call_original()
 
-        # Generic calls works (to_call_original)
-        original_args = ("a", "b")
-        original_kwargs = {"c": "d"}
-        original_instance = target_class(*original_args, **original_kwargs)
-        # self.assertTrue(issubclass(type(original_instance), original_target_class))
-        self.assertEqual(original_instance.args, original_args)
-        self.assertEqual(original_instance.kwargs, original_kwargs)
+                    def reverse_args_wrapper(original_callable, *args, **kwargs):
+                        args = reversed(args)
+                        kwargs = {value: key for key, value in kwargs.items()}
+                        return original_callable(*args, **kwargs)
 
-        # for_call registered calls works
-        mocked_instance = target_class(*mock_args, **mock_kwargs)
-        self.assertEqual(mocked_instance, "mocked")
+                    self.mock_constructor(
+                        self.target_module, target_class_name
+                    ).for_call("Hello", "World", Hello="World").with_wrapper(
+                        reverse_args_wrapper
+                    )
 
-    @context.example
-    def accepts_module_as_string(self):
-        args = (6, 7)
-        kwargs = {"8": 9, "10": 11}
-        self.mock_constructor(self.target_module.__name__, target_class_name).for_call(
-            *args, **kwargs
-        ).to_return_value("mocked")
-        target_class = getattr(self.target_module, target_class_name)
-        mocked_instance = target_class(*args, **kwargs)
-        self.assertEqual(mocked_instance, "mocked")
+                @context.memoize
+                def target(self):
+                    return self.get_target_class()("Hello", "World", Hello="World")
+
+                @context.xexample
+                def wrapped_instance_is_instance_of_original_class(self):
+                    self.assertIsInstance(self.target, original_target_class)
+
+                @context.example
+                def constructor_is_wrapped(self):
+                    self.assertSequenceEqual(self.target.args, ("World", "Hello"))
+                    self.assertSequenceEqual(self.target.kwargs, {"World": "Hello"})
+
+                @context.example("super(Target, self) works")
+                def super_works(self):
+                    self.assertEqual(self.target.calls_super(), "from super")
+
+                @context.example("works with .to_call_original()")
+                def works_with_to_call_original(self):
+                    other_args = (1, 2)
+                    other_kwargs = {"one": 1, "two": 2}
+                    target = self.get_target_class()(*other_args, **other_kwargs)
+                    self.assertSequenceEqual(target.args, other_args)
+                    self.assertSequenceEqual(target.kwargs, other_kwargs)
+
+                @context.example
+                def factory_works(self):
+                    def factory(original_callable, message):
+                        return "got: {}".format(message)
+
+                    self.mock_constructor(
+                        self.target_module, target_class_name
+                    ).for_call("factory").with_wrapper(factory)
+                    target = self.get_target_class()("factory")
+                    self.assertEqual(target, "got: factory")

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -102,7 +102,7 @@ def mock_constructor(target, class_name):
         callable_mock = _CallableMock(original_class, "__new__")
 
         mocked_class = type(
-            str(original_class.__name__ + "MOCK"),
+            str(original_class.__name__),
             tuple(original_class.mro()[1:]),
             {
                 name: value
@@ -110,7 +110,7 @@ def mock_constructor(target, class_name):
                 if name not in ("__new__", "__init__")
             },
         )
-        # FIXME __instancecheck__(self, instance)
+
         def skip_init(self, *args, **kwargs):
             """
             Avoids __init__ being called automatically with different arguments

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -12,7 +12,7 @@ import inspect
 import six
 
 import testslide
-from testslide.mock_callable import _MockCallableDSL, _CallableMock, _Runner
+from testslide.mock_callable import _MockCallableDSL, _CallableMock
 
 _unpatchers = []  # type: List[Callable]  # noqa T484
 
@@ -140,7 +140,6 @@ def mock_constructor(target, class_name):
         # (potentially with different arguments)
         _skip_init.append(id(instance))
         return instance
-        # return original_class(*args, **kwargs)
 
     return _MockConstructorDSL(
         target=mocked_class,


### PR DESCRIPTION
The way `mock_constructor()` patching works, it breaks the behavior of `super()` when called from inside any methods, whenever `with_wrapper()` is used:

```python
super(Target, self)
```
will always fail, because after the patching, `Target` will be a subclass of `Target` (`TargetMock`), and `self`, an instance of `Target`, thus giving us:

```
`TypeError: super(type, obj): obj must be an instance or subtype of type`.
```

This PR changes the strategy used for patching:

- It creates a subclass of `Target`.
- Copy all attributes from `Target` to the new subclass.
- Patch the new subclass in place of the original class.

Things being like this, any `super` calls will always work. It comes though, with some issues:

- After `__new__` is called, the interpreter unconditionally calls `__init__`, with the default arguments. Thanks to @danielkza new test coverage, this issue was surfaced, and a mechanism was added to call `__init__` only once with the correct arguments.

There are a few things missing to fully wrap up this issue:

- Potentially add a safety check: if there's more than 1 reference to the class being patched, as there's no guarantee things would work in this scenario.
- Make sure this works with metaclasses (add tests).

CC @lucasvasconcelos 