### PR TITLE
Fix mock_constructor() with Generic classes

### DIFF
--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -32,14 +32,13 @@ class Target(BaseTarget):
         return super(Target, self).calls_super()
 
 
-if sys.version_info[0] >= 3:
-    from typing import TypeVar, Generic, List
+if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+    from typing import TypeVar, Generic
 
     SomeType = TypeVar("SomeType")
 
     class GenericTarget(Generic[SomeType]):
-        def __init__(self) -> None:
-            self.items: List[SomeType] = []
+        pass
 
 
 original_target_class = Target
@@ -102,7 +101,7 @@ def mock_constructor(context):
             with self.assertRaisesWithMessage(ValueError, "Target must be a class."):
                 self.mock_constructor(self.target_module, "dummy")
 
-    if sys.version_info[0] >= 3:
+    if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
 
         @context.sub_context
         def Generic_classes(context):

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -105,10 +105,10 @@ def mock_constructor(target, class_name):
 
         callable_mock = _CallableMock(original_class, "__new__")
 
-        if sys.version_info[0] >= 3:
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
             mro = tuple(c for c in original_class.mro()[1:] if c is not typing.Generic)
         else:
-            mro = original_class.mro()[1:]
+            mro = tuple(original_class.mro()[1:])
         mocked_class = type(
             str(original_class.__name__),
             mro,

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -10,6 +10,10 @@ from __future__ import unicode_literals
 
 import inspect
 import six
+import sys
+
+if sys.version_info[0] >= 3:
+    import typing
 
 import testslide
 from testslide.mock_callable import _MockCallableDSL, _CallableMock
@@ -101,9 +105,13 @@ def mock_constructor(target, class_name):
 
         callable_mock = _CallableMock(original_class, "__new__")
 
+        if sys.version_info[0] >= 3:
+            mro = tuple(c for c in original_class.mro()[1:] if c is not typing.Generic)
+        else:
+            mro = original_class.mro()[1:]
         mocked_class = type(
             str(original_class.__name__),
-            tuple(original_class.mro()[1:]),
+            mro,
             {
                 name: value
                 for name, value in original_class.__dict__.items()


### PR DESCRIPTION
`type()` refuses to create new instances of [Generic classes](https://docs.python.org/3/library/typing.html#typing.Generic):

```
TypeError: Cannot inherit from plain Generic
```

so we need to exclude generic classes from `mro()` list before creating the new class.