### PR TITLE
Make mock_callable() refuse non callable targets

### DIFF
--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -423,13 +423,13 @@ def _patch(target, method, new_value):
         original_callable = getattr(target, method)
         if not callable(original_callable):
             raise ValueError(
-                "mock_callable() can only be used with callable attributes, got: {}".format(
+                "mock_callable() can only be used with callable attributes and {} is not.".format(
                     repr(original_callable)
                 )
             )
         if type(original_callable) is type:
             raise ValueError(
-                "mock_callable() can not be used with functions and methods, got: {}".format(
+                "mock_callable() can not be used with with classes: {}. Perhaps you want to use mock_constructor() instead.".format(
                     repr(original_callable)
                 )
             )

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -421,6 +421,14 @@ def _patch(target, method, new_value):
         original_callable = None
     else:
         original_callable = getattr(target, method)
+        if not callable(original_callable):
+            raise ValueError(
+                "mock_callable() can only be used with callable attributes!"
+            )
+        if type(original_callable) is type:
+            raise ValueError(
+                "mock_callable() can not be used with functions and methods!"
+            )
 
     new_value = _add_signature_validation(new_value, target, method)
     restore_value = target.__dict__.get(method, None)

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -423,11 +423,15 @@ def _patch(target, method, new_value):
         original_callable = getattr(target, method)
         if not callable(original_callable):
             raise ValueError(
-                "mock_callable() can only be used with callable attributes!"
+                "mock_callable() can only be used with callable attributes, got: {}".format(
+                    repr(original_callable)
+                )
             )
         if type(original_callable) is type:
             raise ValueError(
-                "mock_callable() can not be used with functions and methods!"
+                "mock_callable() can not be used with functions and methods, got: {}".format(
+                    repr(original_callable)
+                )
             )
 
     new_value = _add_signature_validation(new_value, target, method)

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -427,7 +427,7 @@ def _patch(target, method, new_value):
                     repr(original_callable)
                 )
             )
-        if type(original_callable) is type:
+        if inspect.isclass(original_callable):
             raise ValueError(
                 "mock_callable() can not be used with with classes: {}. Perhaps you want to use mock_constructor() instead.".format(
                     repr(original_callable)


### PR DESCRIPTION
`mock_callable()` only works (and is only tested) to work with functions and methods. Let's give a fast failure, in case some other target is given, like a non callable attribute or a class.