### PR TITLE
Fix mock constructor patching

### DIFF
--- a/docs/mock_constructor/index.rst
+++ b/docs/mock_constructor/index.rst
@@ -48,12 +48,34 @@ The question now is: how to put ``self.storage_mock`` inside ``Backup.__init__``
         .and_assert_called_once()
       Backup().delete('/file/to/delete')
 
-mock_constructor makes ``storage.Client(timeout=60)`` return ``self.storage_mock``. It is similar to :doc:`../mock_callable/index`, accepting the same call, behavior and assertion definitions. Similarly, it will also fail if ``storage.Client()`` (missing timeout) is called.
+``mock_constructor()`` makes ``storage.Client(timeout=60)`` return ``self.storage_mock``. It is similar to :doc:`../mock_callable/index`, accepting the same call, behavior and assertion definitions. Similarly, it will also fail if ``storage.Client()`` (missing timeout) is called.
 
-Note how by using mock_constructor, not only you get all **safe by default** goodies, but also **totally decouples** your test from the code. This means that, no matter how ``Backup`` is refactored, the test remains the same.
+Note how by using ``mock_constructor()``, not only you get all **safe by default** goodies, but also **totally decouples** your test from the code. This means that, no matter how ``Backup`` is refactored, the test remains the same.
+
+Caveats
+-------
+
+Because of the way ``mock_constructor()`` must be implemented (see next section), its usage must respect these rules:
+
+- References to the mocked class, saved prior to ``mock_constructor()`` invocation **can not be used**.
+- Access to the class must happen exclusively via attribute access (eg: ``getattr(some_module, "SomeClass")``).
+
+A simple easy way to ensure this is to always:
+
+.. code-block:: python
+
+  # Do this:
+  import some_module
+  some_module.SomeClass
+  # Never do:
+  from some_module import SomeClass
+
+.. note::
+
+  Not respecting these rules will break ``mock_constructor()`` and can lead to unpredicted behavior!
 
 Implementation Details
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 ``mock_callable()`` should be all you need:
 
@@ -63,18 +85,22 @@ Implementation Details
     .for_call()\
     .to_return_value(some_class_mock)
 
-However, as of July 2019, Python 3 has an open bug https://bugs.python.org/issue25731 that prevents this from working. ``mock_constructor`` is a way around this bug.
+However, as of July 2019, Python 3 has an open bug https://bugs.python.org/issue25731 that prevents ``__new__`` from being patched. ``mock_constructor()`` is a way around this bug.
 
-Because ``__new__`` can not be patched, we need to handle things elsewhere:
+Because ``__new__`` can not be patched, we need to handle things elsewhere. The trick is to dynamically create a subclass of the target class, make the changes to ``__new__`` there (so we don't touch ``__new__`` at the target class), and patch it at the module in place of the original class.
 
-* Dynamically create a subclass of the target class, with the same name.
-* Move all ``__dict__`` values from the target class to the subclass (with a few exceptions).
-* In the subclass, add a ``__new__`` that works as a factory, that allows ``mock_callable()`` to work.
-* Do some trickery to fix the arguments passed to ``__init__`` to allow ``.with_wrapper()`` mangle with them (as by default,``__new__`` unconditionally calls ``__init__`` with the same arguments received).
+This works when ``__new__`` simply returns a mocked value, but creates issues when used with ``.with_wrapper()`` or ``.to_call_original()`` as both requires calling the original ``__new__``. This will return an instance of the original class, but the new subclass is already patched at the module, thus ``super()`` / ``super(Class, self)`` breaks. If we make them call ``__new__`` from the subclass, the call comes from... ``__new__`` and we get an infinite loop. Also, ``__new__`` calls ``__init__`` unconditionally, not allowing ``.with_wrapper()`` to mangle with the arguments.
+
+The way around this, is to keep the original class where it is and move all its attributes to the child class:
+
+* Dynamically create the subclass of the target class, with the same name.
+* Move all ``__dict__`` values from the target class to the subclass (with a few exceptions, such as ``__new__`` and ``__module__``).
+* At the subclass, add a ``__new__`` that works as a factory, that allows ``mock_callable()`` interface to work.
+* Do some trickery to fix the arguments passed to ``__init__`` to allow ``.with_wrapper()`` mangle with them.
 * Patch the subclass in place of the original target class at its module.
 * Undo all of this when the test finishes.
 
-As this effectively only changes the behavior of ``__new__``, things like class attributes, class methods and ``isinstance()`` are not affected. The only noticeable difference, is that ``mro()`` will show the extra subclass.
+This essentially creates a "copy" of the class, at the subclass, but with ``__new__`` implementing the behavior required. All things such as class attributes/methods and ``isinstance()`` are not affected. The only noticeable difference, is that ``mro()`` will show the extra subclass.
 
 Integration With Other Frameworks
 ---------------------------------

--- a/docs/mock_constructor/index.rst
+++ b/docs/mock_constructor/index.rst
@@ -57,7 +57,7 @@ Caveats
 
 Because of the way ``mock_constructor()`` must be implemented (see next section), its usage must respect these rules:
 
-- References to the mocked class, saved prior to ``mock_constructor()`` invocation **can not be used**.
+- References to the mocked class saved prior to ``mock_constructor()`` invocation **can not be used**, including previously created instances.
 - Access to the class must happen exclusively via attribute access (eg: ``getattr(some_module, "SomeClass")``).
 
 A simple easy way to ensure this is to always:

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -106,17 +106,17 @@ def mock_constructor(context):
             ),
         )
 
-    # @context.before
-    # def assert_unpatched(self):
-    #     self.assertTrue(
-    #         original_target_class is self.get_target_class(), "Unpatching didn't work."
-    #     )
-    #     args = (1, 2)
-    #     kwargs = {"3": 4, "5": 6}
-    #     t = Target(*args, **kwargs)
-    #     self.assertEqual(type(t), original_target_class)
-    #     self.assertEqual(t.args, args)
-    #     self.assertEqual(t.kwargs, kwargs)
+    @context.before
+    def assert_unpatched(self):
+        self.assertTrue(
+            original_target_class is self.get_target_class(), "Unpatching didn't work."
+        )
+        args = (1, 2)
+        kwargs = {"3": 4, "5": 6}
+        t = Target(*args, **kwargs)
+        self.assertEqual(type(t), original_target_class)
+        self.assertEqual(t.args, args)
+        self.assertEqual(t.kwargs, kwargs)
 
     @context.shared_context
     def class_attributes(context):
@@ -140,7 +140,7 @@ def mock_constructor(context):
                     "p2_super_class_method",
                 )
 
-            @context.xexample("super() works")
+            @context.example("super() works")
             def p3_super_works(self):
                 self.assertEqual(
                     self.class_attribute_target.p3_super_class_method(),
@@ -260,7 +260,7 @@ def mock_constructor(context):
                         self.target_module, self.target_class_name
                     ).with_wrapper(wrapper)
 
-                @context.xexample
+                @context.example
                 def wrapped_instance_is_instance_of_original_class(self):
                     self.assertIsInstance(self.target, original_target_class)
 
@@ -288,12 +288,12 @@ def mock_constructor(context):
 
                 @context.sub_context("Target.__init__()")
                 def target_init(context):
-                    @context.xexample("super(Target, self)")
+                    @context.example("super(Target, self)")
                     def p2_super_works(self):
                         target = self.get_target_class()(p2_super=True)
                         self.assertTrue(target.p2_super)
 
-                    @context.xexample("super() works")
+                    @context.example("super() works")
                     def p3_super_works(self):
                         target = self.get_target_class()(p3_super=True)
                         self.assertTrue(target.p3_super)
@@ -316,7 +316,7 @@ def mock_constructor(context):
                                 "p2_super_instance_method",
                             )
 
-                        @context.xexample("super() works")
+                        @context.example("super() works")
                         def p3_super_works(self):
                             self.assertEqual(
                                 self.target.p3_super_instance_method(),

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -53,6 +53,8 @@ class Target(TargetParent):
 
         super(Target, self).__init__(*args, **kwargs)
 
+        self.dynamic_attr = "dynamic_attr"
+
     def regular_instance_method(self):
         return "regular_instance_method"
 
@@ -163,9 +165,16 @@ def mock_constructor(context):
         self.mock_callable(
             target_mock, "regular_instance_method"
         ).for_call().to_return_value("mocked")
+        # Test that dynamic attributes can be read from the template
+        target_mock.dynamic_attr = "mocked_attr"
         target = self.get_target_class()()
-        self.assertIs(target, target_mock)
-        self.assertEqual(target.regular_instance_method(), "mocked")
+        self.assertIs(target, target_mock, "mock_constructor() patching did not work")
+        self.assertEqual(
+            target.regular_instance_method(),
+            "mocked",
+            "mock_callable() patching did not work.",
+        )
+        self.assertEqual(target.dynamic_attr, "mocked_attr")
 
     @context.sub_context
     def arguments(context):

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -153,10 +153,19 @@ def mock_constructor(context):
                     "p3_super_class_method",
                 )
 
+    @context.example
+    def rejects_attribute_access_at_the_original_class(self):
+        self.mock_constructor(self.target_module, self.target_class_name)
+        with self.assertRaisesWithMessageInException(
+            RuntimeError,
+            "mock_constructor() requires old references to the class not to be used, please get a new reference to it.",
+        ):
+            original_target_class.CLASS_ATTR
+
     @context.sub_context
     def arguments(context):
         @context.example
-        def refuses_to_mock_if_instances_exists(self):
+        def refuses_to_mock_if_instances_exist(self):
             target_instance = self.get_target_class()()
             with self.assertRaisesWithMessageInException(
                 RuntimeError,

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -46,8 +46,9 @@ class Target(BaseTarget):
         self.p2_super = False
         super(Target, self).__init__(p2_super=True)
 
-        self.p3_super = False
-        super().__init__(p3_super=True)
+        if sys.version_info[0] >= 3:
+            self.p3_super = False
+            super().__init__(p3_super=True)
 
         super(Target, self).__init__(*args, **kwargs)
 
@@ -68,9 +69,11 @@ class Target(BaseTarget):
     def p2_super_class_method(cls):
         return super(Target, cls).p2_super_class_method()
 
-    @classmethod
-    def p3_super_class_method(cls):
-        return super().p3_super_class_method()
+    if sys.version_info[0] >= 3:
+
+        @classmethod
+        def p3_super_class_method(cls):
+            return super().p3_super_class_method()
 
 
 original_target_class = Target
@@ -293,10 +296,12 @@ def mock_constructor(context):
                         target = self.get_target_class()(p2_super=True)
                         self.assertTrue(target.p2_super)
 
-                    @context.example("super() works")
-                    def p3_super_works(self):
-                        target = self.get_target_class()(p3_super=True)
-                        self.assertTrue(target.p3_super)
+                    if sys.version_info[0] >= 3:
+
+                        @context.example("super() works")
+                        def p3_super_works(self):
+                            target = self.get_target_class()(p3_super=True)
+                            self.assertTrue(target.p3_super)
 
                     @context.example
                     def can_be_called_again(self):
@@ -324,9 +329,11 @@ def mock_constructor(context):
                                 "p2_super_instance_method",
                             )
 
-                        @context.example("super() works")
-                        def p3_super_works(self):
-                            self.assertEqual(
-                                self.target.p3_super_instance_method(),
-                                "p3_super_instance_method",
-                            )
+                        if sys.version_info[0] >= 3:
+
+                            @context.example("super() works")
+                            def p3_super_works(self):
+                                self.assertEqual(
+                                    self.target.p3_super_instance_method(),
+                                    "p3_super_instance_method",
+                                )

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -13,9 +13,10 @@ import contextlib
 
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 from testslide.mock_callable import _MockCallableDSL
+from testslide.strict_mock import StrictMock
 
 
-class BaseTarget(object):
+class TargetParent(object):
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
@@ -39,7 +40,7 @@ class BaseTarget(object):
         return "p3_super_class_method"
 
 
-class Target(BaseTarget):
+class Target(TargetParent):
     CLASS_ATTR = "CLASS_ATTR"
 
     def __init__(self, *args, **kwargs):
@@ -149,6 +150,22 @@ def mock_constructor(context):
                     self.class_attribute_target.p3_super_class_method(),
                     "p3_super_class_method",
                 )
+
+    @context.example
+    def it_works_with_StrictMock_and_mock_callable(self):
+        """
+        Make sure this usual idiom is supported.
+        """
+        target_mock = StrictMock(template=self.get_target_class())
+        self.mock_constructor(
+            self.target_module, self.target_class_name
+        ).for_call().to_return_value(target_mock)
+        self.mock_callable(
+            target_mock, "regular_instance_method"
+        ).for_call().to_return_value("mocked")
+        target = self.get_target_class()()
+        self.assertIs(target, target_mock)
+        self.assertEqual(target.regular_instance_method(), "mocked")
 
     @context.sub_context
     def arguments(context):

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -134,6 +134,12 @@ def mock_constructor(context):
         def attributes_are_not_affected(self):
             self.assertEqual(self.class_attribute_target.CLASS_ATTR, "CLASS_ATTR")
 
+        @context.example
+        def static_methods_are_not_affected(self):
+            self.assertEqual(
+                self.class_attribute_target.static_method(), "static_method"
+            )
+
         @context.sub_context
         def class_methods(context):
             @context.example

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -198,7 +198,7 @@ def mock_constructor(context):
             self.assertEqual(target_two.args, ("two",))
 
         @context.sub_context
-        def origianl_class_attribute_access(context):
+        def original_class_attribute_access(context):
             @context.before
             def mock_constructor(self):
                 self.mock_constructor(

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -165,8 +165,9 @@ def mock_constructor(context):
         self.mock_callable(
             target_mock, "regular_instance_method"
         ).for_call().to_return_value("mocked")
-        # Test that dynamic attributes can be read from the template
-        target_mock.dynamic_attr = "mocked_attr"
+        if sys.version_info[0] >= 3:
+            # Test that dynamic attributes can be read from the template
+            target_mock.dynamic_attr = "mocked_attr"
         target = self.get_target_class()()
         self.assertIs(target, target_mock, "mock_constructor() patching did not work")
         self.assertEqual(
@@ -174,7 +175,8 @@ def mock_constructor(context):
             "mocked",
             "mock_callable() patching did not work.",
         )
-        self.assertEqual(target.dynamic_attr, "mocked_attr")
+        if sys.version_info[0] >= 3:
+            self.assertEqual(target.dynamic_attr, "mocked_attr")
 
     @context.sub_context
     def arguments(context):

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -298,6 +298,14 @@ def mock_constructor(context):
                         target = self.get_target_class()(p3_super=True)
                         self.assertTrue(target.p3_super)
 
+                    @context.example
+                    def can_be_called_again(self):
+                        new_args = ("new", "args")
+                        new_kwargs = {"new": "kwargs"}
+                        self.target.__init__(*new_args, **new_kwargs)
+                        self.assertEqual(self.target.args, new_args)
+                        self.assertEqual(self.target.kwargs, new_kwargs)
+
                 @context.sub_context
                 def instance_methods(context):
                     @context.example

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -164,7 +164,7 @@ def mock_constructor(context):
                 )
 
     @context.sub_context
-    def patching_mechanism_protection(context):
+    def patching_mechanism(context):
         @context.example
         def can_not_mock_constructor_with_existing_instances(self):
             original_target = original_target_class()
@@ -177,6 +177,25 @@ def mock_constructor(context):
                 self.mock_constructor(
                     self.target_module, self.target_class_name
                 ).to_call_original()
+
+        @context.example
+        def works_with_composition(self):
+            self.mock_constructor(self.target_module, self.target_class_name).for_call(
+                1
+            ).with_wrapper(
+                lambda original_callable, *args, **kwargs: original_callable("one")
+            )
+            self.mock_constructor(self.target_module, self.target_class_name).for_call(
+                2
+            ).with_wrapper(
+                lambda original_callable, *args, **kwargs: original_callable("two")
+            )
+
+            target_one = self.get_target_class()(1)
+            self.assertEqual(target_one.args, ("one",))
+
+            target_two = self.get_target_class()(2)
+            self.assertEqual(target_two.args, ("two",))
 
         @context.sub_context
         def origianl_class_attribute_access(context):

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -434,7 +434,8 @@ def _patch(target, method, new_value):
                 )
             )
 
-    new_value = _add_signature_validation(new_value, target, method)
+    if not isinstance(target, StrictMock):
+        new_value = _add_signature_validation(new_value, target, method)
     restore_value = target.__dict__.get(method, None)
 
     if inspect.isclass(target):

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -140,7 +140,7 @@ def _get_mocked_class(original_class, target_class_id, callable_mock):
             _init_args_from_original_callable = None
             _init_kwargs_from_original_callable = None
         # Restore __init__ so subsequent calls can work.
-        setattr(mocked_class, "__init__", init)
+        mocked_class.__init__ = init
 
     mocked_class.__init__ = init_with_correct_args
 

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -206,21 +206,21 @@ def _get_mocked_class(original_class, target_class_id, callable_mock):
     # __init__ with the correct arguments.
     def init_with_correct_args(self, *args, **kwargs):
         global _init_args_from_original_callable, _init_kwargs_from_original_callable
-        assert _init_args_from_original_callable is not None
-        assert _init_kwargs_from_original_callable is not None
+        if None not in [
+            _init_args_from_original_callable,
+            _init_kwargs_from_original_callable,
+        ]:
+            args = _init_args_from_original_callable
+            kwargs = _init_kwargs_from_original_callable
+
         original_init = _get_original_init(
             original_class, instance=self, owner=mocked_class
         )
         try:
-            original_init(
-                *_init_args_from_original_callable,
-                **_init_kwargs_from_original_callable
-            )
+            original_init(*args, **kwargs)
         finally:
             _init_args_from_original_callable = None
             _init_kwargs_from_original_callable = None
-        # Restore __init__ so subsequent calls can work.
-        mocked_class.__init__ = original_init
 
     mocked_class.__init__ = init_with_correct_args
 

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -119,7 +119,7 @@ def _get_mocked_class(original_class, target_class_id, callable_mock):
             delattr(original_class, name)
         # Safety net against missing items at _DO_NOT_COPY_CLASS_ATTRIBUTES
         except (AttributeError, TypeError):
-            pass
+            continue
         _restore_dict[target_class_id][name] = value
     # ...and reuse them...
     mocked_class_dict = {"__new__": callable_mock}

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -132,7 +132,7 @@ def _get_mocked_class(original_class, target_class_id, callable_mock):
 
     # ...to create the mocked subclass.
     mocked_class = type(
-        str(original_class.__name__) + "Mock", (original_class,), mocked_class_dict
+        str(original_class.__name__), (original_class,), mocked_class_dict
     )
 
     # Because __init__ is called after __new__ unconditionally with the same

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -24,7 +24,7 @@ def _add_signature_validation(value, template, attr_name):
 
     if isinstance(template, StrictMock):
         if "__template" in template.__dict__:
-            template = template.__dict__["__template"]
+            template = template.__template
         else:
             return value
 

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -211,7 +211,10 @@ class StrictMock(object):
 
     @property
     def __template(self):
-        return self.__dict__["__template"]
+        # Import here to avoid cyclic dependencies during import
+        from testslide.mock_constructor import _get_template
+
+        return _get_template(self.__dict__["__template"])
 
     @property
     def __template_name(self):


### PR DESCRIPTION
#34 and #35 attempted to fix the patching mechanism of `mock_constructor()`, but many breaking scenarios appeared.

This PR addresses a **lot** of cases, covered by a lot of new tests:

- Many use cases for `super` are covered.
- Integration with `mock_callable()`.
- Integration with `StrictMock`.
- Add validation for existing instances prior to `mock_constructor()` (not supported).
- Protect the original class after the mock against wrong usage (AttrAccessValidation).

The documentation was also updated, and details the requirements for using `mock_constructor()` and the trickeries that go under the hood.