### PR TITLE
Reject old style classes with mock_constructor()

### DIFF
--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -295,6 +295,8 @@ def mock_constructor(target, class_name):
 
         if not inspect.isclass(original_class):
             raise ValueError("Target must be a class.")
+        elif type(original_class) is not type:
+            raise ValueError("Old style classes are not supported.")
         callable_mock = _CallableMock(original_class, "__new__")
         mocked_class = _patch_and_return_mocked_class(
             target, class_name, target_class_id, original_class, callable_mock

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -295,7 +295,7 @@ def mock_constructor(target, class_name):
 
         if not inspect.isclass(original_class):
             raise ValueError("Target must be a class.")
-        elif type(original_class) is not type:
+        elif not issubclass(original_class, object):
             raise ValueError("Old style classes are not supported.")
         callable_mock = _CallableMock(original_class, "__new__")
         mocked_class = _patch_and_return_mocked_class(


### PR DESCRIPTION
They won't work anyway, no point in supporting this kind of legacy...