### PR TITLE
adds --fail-if-focused option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ unittest_tests:
 
 .PHONY: testslide_tests
 testslide_tests:
-	python -m testslide.cli --show-testslide-stack-trace --fail-fast tests/*_testslide.py
+	python -m testslide.cli --show-testslide-stack-trace --fail-fast --fail-if-focused tests/*_testslide.py
 
 .PHONY: docs
 docs:

--- a/docs/test_runner/index.rst
+++ b/docs/test_runner/index.rst
@@ -114,6 +114,9 @@ And then run your tests with ``--focus``:
 
 Only ``ftest`` tests will be executed. Note that it also tells you how many tests were not executed.
 
+When you are committing tests to a continuous integration system, focusing tests may not be the best choice. You can
+use the cli option ``--fail-if-focused`` which will cause TestSlide to fail if any focused examples are run.
+
 Similarly, you can skip a test with ``x``:
 
 .. code-block:: python

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -345,6 +345,17 @@ class TestCliDocumentation(TestCliBase):
         ):
             self.execute()
 
+    def test_fail_if_focus(self):
+        """
+        Fail because there are focused tests and --fail-if-focused
+        """
+        self.argv.append("--fail-if-focused")
+        with self.assert_in_stdout(
+            "Focused example not allowed with --fail-if-focused."
+            " Please remove the focus to allow the test to run."
+        ):
+            self.execute(expected_return_value=1)
+
     def test_fail_fast(self):
         """
         Stop execution when first example fails.

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -197,6 +197,11 @@ class Cli(object):
             help="Only executed focused examples, or all if none focused",
         )
         parser.add_argument(
+            "--fail-if-focused",
+            action="store_true",
+            help="Raise an error if an example is focused. Useful when running tests in a continuous integration environment.",
+        )
+        parser.add_argument(
             "--fail-fast",
             action="store_true",
             help="Stop execution when an example fails",
@@ -324,6 +329,7 @@ class Cli(object):
         config.list = parsed_args.list
         config.seed = parsed_args.seed[0] if parsed_args.seed else None
         config.focus = parsed_args.focus
+        config.fail_if_focused = parsed_args.fail_if_focused
         config.fail_fast = parsed_args.fail_fast
         config.names_text_filter = (
             parsed_args.filter_text[0] if parsed_args.filter_text else None
@@ -380,6 +386,7 @@ class Cli(object):
                     seed=config.seed,
                     focus=config.focus,
                     fail_fast=config.fail_fast,
+                    fail_if_focused=config.fail_if_focused,
                     names_text_filter=config.names_text_filter,
                     names_regex_filter=config.names_regex_filter,
                     names_regex_exclude=config.names_regex_exclude,

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -308,6 +308,7 @@ class Runner(object):
         seed=None,
         focus=False,
         fail_fast=False,
+        fail_if_focused=False,
         names_text_filter=None,
         names_regex_filter=None,
         names_regex_exclude=None,
@@ -319,12 +320,19 @@ class Runner(object):
         self.seed = seed
         self.focus = focus
         self.fail_fast = fail_fast
+        self.fail_if_focused = fail_if_focused
         self.names_text_filter = names_text_filter
         self.names_regex_filter = names_regex_filter
         self.names_regex_exclude = names_regex_exclude
         self.quiet = quiet
 
     def _run_example(self, example):
+        if example.focus and self.fail_if_focused:
+            with _add_traceback_context_manager():
+                raise AssertionError(
+                    "Focused example not allowed with --fail-if-focused"
+                    ". Please remove the focus to allow the test to run."
+                )
         if self.quiet:
             stdout = six.StringIO()
             stderr = six.StringIO()


### PR DESCRIPTION

Adds an option to fail if any examples are focused, useful for internal fb use.