### PR TITLE
Improve test framework integration docs

### DIFF
--- a/docs/mock_callable/index.rst
+++ b/docs/mock_callable/index.rst
@@ -414,7 +414,7 @@ Integration comes out of the box for :doc:`../testslide_dsl/index`: you can simp
 Python Unittest
 ^^^^^^^^^^^^^^^
 
-``testslide.TestCase`` is provided with of the shelf integration ready:
+``testslide.TestCase`` is provided with off the shelf integration ready:
 
 - Inherit your ``unittest.TestCase`` from it.
 - If you overload ``unittest.TestCase.setUp``, make **sure** to call ``super().setUp()`` before using ``mock_callable()``.

--- a/docs/mock_callable/index.rst
+++ b/docs/mock_callable/index.rst
@@ -403,10 +403,26 @@ This is particularly helpful when changes are introduced to the code: if a mocke
 
   This feature is **not** available in Python 2!
 
-Integration With Other Frameworks
----------------------------------
+Test Framework Integration
+--------------------------
 
-mock_callable comes out of the box with support for Python`s unittest (via ``testslide.TestCase``) and :doc:`../testslide_dsl/index`. You can easily integrate it with any other test framework you prefer:
+TestSlide's DSL
+^^^^^^^^^^^^^^^
+
+Integration comes out of the box for :doc:`../testslide_dsl/index`: you can simply do ``self.mock_callable()`` from inside examples or hooks.
+
+Python Unittest
+^^^^^^^^^^^^^^^
+
+``testslide.TestCase`` is provided with of the shelf integration ready:
+
+- Inherit your ``unittest.TestCase`` from it.
+- If you overload ``unittest.TestCase.setUp``, make **sure** to call ``super().setUp()`` before using ``mock_callable()``.
+
+Any Test Framework
+^^^^^^^^^^^^^^^^^^
+
+You must follow these steps for **each** test executed that uses ``mock_callable()``:
 
 * mock_callable calls ``testslide.mock_callable.register_assertion`` passing a callable object whenever an assertion is defined. You must set it to a function that will execute the assertion **after** the test code finishes. Eg: for Python's unittest: ``testslide.mock_callable.register_assertion = lambda assertion: self.addCleanup(assertion)``.
 * After each test execution, you must **unconditionally** call ``testslide.mock_callable.unpatch_all_callable_mocks``. This will undo all patches, so the next test is not affected by them. Eg: for Python's unittest: ``self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)``.

--- a/docs/mock_constructor/index.rst
+++ b/docs/mock_constructor/index.rst
@@ -102,11 +102,27 @@ The way around this, is to keep the original class where it is and move all its 
 
 This essentially creates a "copy" of the class, at the subclass, but with ``__new__`` implementing the behavior required. All things such as class attributes/methods and ``isinstance()`` are not affected. The only noticeable difference, is that ``mro()`` will show the extra subclass.
 
-Integration With Other Frameworks
----------------------------------
+Test Framework Integration
+--------------------------
 
-mock_constructor comes out of the box with support for Python`s unittest (via ``testslide.TestCase``) and :doc:`../testslide_dsl/index`. You can easily integrate it with any other test framework you prefer:
+TestSlide's DSL
+^^^^^^^^^^^^^^^
 
-* Integrate :doc:`../mock_callable/index` (used by mock_constructor under the hook).
+Integration comes out of the box for :doc:`../testslide_dsl/index`: you can simply do ``self.mock_constructor()`` from inside examples or hooks.
+
+Python Unittest
+^^^^^^^^^^^^^^^
+
+``testslide.TestCase`` is provided with of the shelf integration ready:
+
+- Inherit your ``unittest.TestCase`` from it.
+- If you overload ``unittest.TestCase.setUp``, make **sure** to call ``super().setUp()`` before using ``mock_constructor()``.
+
+Any Test Framework
+^^^^^^^^^^^^^^^^^^
+
+You must follow these steps for **each** test executed that uses ``mock_constructor()``:
+
+* Integrate :doc:`../mock_callable/index` (used by mock_constructor under the hood).
 * After each test execution, you must **unconditionally** call ``testslide.mock_constructor.unpatch_all_callable_mocks``. This will undo all patches, so the next test is not affected by them. Eg: for Python's unittest: ``self.addCleanup(testslide.mock_constructor.unpatch_all_callable_mocks)``.
 * You can then call ``testslide.mock_constructor.mock_constructor`` directly from your tests.

--- a/docs/mock_constructor/index.rst
+++ b/docs/mock_constructor/index.rst
@@ -113,7 +113,7 @@ Integration comes out of the box for :doc:`../testslide_dsl/index`: you can simp
 Python Unittest
 ^^^^^^^^^^^^^^^
 
-``testslide.TestCase`` is provided with of the shelf integration ready:
+``testslide.TestCase`` is provided with off the shelf integration ready:
 
 - Inherit your ``unittest.TestCase`` from it.
 - If you overload ``unittest.TestCase.setUp``, make **sure** to call ``super().setUp()`` before using ``mock_constructor()``.


### PR DESCRIPTION
With #45  we now validate wrong mock_callable usage. The error message points to the docs, but it was not explicit about calling `super().setUp()`, which can confuse users.

This PR improve the docs, hopefully making these issues easier to fix.