### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
 install:

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -6,7 +6,7 @@
 import unittest
 import sys
 from contextlib import contextmanager
-from testslide import redirect_stdout, redirect_stderr
+from contextlib import redirect_stdout, redirect_stderr
 
 from unittest.mock import patch
 

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -5,8 +5,7 @@
 
 import unittest
 import sys
-from contextlib import contextmanager
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import contextmanager, redirect_stdout, redirect_stderr
 
 from unittest.mock import patch
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -15,31 +15,11 @@ import testslide.mock_callable
 import testslide.mock_constructor
 from testslide.strict_mock import StrictMock  # noqa
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
-    from contextlib import redirect_stdout, redirect_stderr
-else:
 
-    @contextmanager
-    def redirect_stdout(target):
-        original = sys.stdout
-        sys.stdout = target
-        try:
-            yield
-        finally:
-            sys.stdout = original
-
-    @contextmanager
-    def redirect_stderr(target):
-        original = sys.stderr
-        sys.stderr = target
-        try:
-            yield
-        finally:
-            sys.stderr = original
-
-
-if sys.version_info[0] < 3:
-    raise RuntimeError("Python >=3 required.")
+if sys.version_info[0] < 3 or (
+    sys.version_info.major == 3 and sys.version_info.minor < 6
+):
+    raise RuntimeError("Python >=3.6 required.")
 
 
 def _importer(target):

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -16,9 +16,7 @@ import testslide.mock_constructor
 from testslide.strict_mock import StrictMock  # noqa
 
 
-if sys.version_info[0] < 3 or (
-    sys.version_info.major == 3 and sys.version_info.minor < 6
-):
+if sys.version_info < (3, 6):
     raise RuntimeError("Python >=3.6 required.")
 
 

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -10,7 +10,8 @@ import traceback
 import sys
 import os
 
-from . import AggregatedExceptions, Skip, redirect_stdout, redirect_stderr
+from . import AggregatedExceptions, Skip
+from contextlib import redirect_stdout, redirect_stderr
 
 
 class Formatter(object):


### PR DESCRIPTION
Let's not spend time supporting this 4 years old branch and get rid of not being able to use 3.6+ goodies.