### PR TITLE
Refactor CLI tests

### DIFF
--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -3,25 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-import sys
-
-# from contextlib import contextmanager
-# from testslide import redirect_stdout, redirect_stderr
-
-# from unittest.mock import patch
-
-# from testslide import Context
-# from testslide.dsl import context
-# from testslide import cli
-# import traceback
-# import io
-import subprocess
+import copy
 import os
 import os.path
-import copy
-import threading
 import pty
+import subprocess
+import sys
+import threading
+import unittest
 
 
 class TestCliBase(unittest.TestCase):

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -5,104 +5,144 @@
 
 import unittest
 import sys
-from contextlib import contextmanager, redirect_stdout, redirect_stderr
 
-from unittest.mock import patch
+# from contextlib import contextmanager
+# from testslide import redirect_stdout, redirect_stderr
 
-from testslide import Context
-from testslide.dsl import context
-from testslide import cli
-import traceback
-import io
+# from unittest.mock import patch
+
+# from testslide import Context
+# from testslide.dsl import context
+# from testslide import cli
+# import traceback
+# import io
+import subprocess
 import os
-
-
-class SimulatedFailure(Exception):
-    def __init__(self, message, second_message):
-        """
-        This method purposely accepts an extra argument to catch failures when
-        reraising exceptions.
-        """
-        super(SimulatedFailure, self).__init__(message, second_message)
-        self.message = message
-        self.second_message = second_message
-
-    def __str__(self):
-        return "{} {}".format(self.message, self.second_message)
+import os.path
+import copy
+import threading
+import pty
 
 
 class TestCliBase(unittest.TestCase):
-    def _create_contexts(self):
-        @context
-        def top_context(context):
-            @context.example
-            def passing_example(self):
-                pass
-
-            @context.example
-            def failing_example(self):
-                raise SimulatedFailure("test failure", "(extra)")
-
-            @context.fexample
-            def focused_example(self):
-                pass
-
-            @context.xexample
-            def skipped_example(self):
-                pass
-
-            @context.example
-            def unittest_SkipTest(self):
-                raise unittest.SkipTest("Skipped with unittest.SkipTest")
-
-            @context.sub_context
-            def nested_context(context):
-                @context.example
-                def passing_nested_example(self):
-                    pass
+    SAMPLE_DSL_PATH = os.path.dirname(__file__) + "/sample_dsl.py"
 
     def setUp(self):
-        Context.all_top_level_contexts = []
-        self._create_contexts()
-        self.captured_stdout = io.StringIO()
-        self.captured_stderr = io.StringIO()
-        self.argv = []
+        self.argv = [self.SAMPLE_DSL_PATH]
+        self.env = {}
         super(TestCliBase, self).setUp()
 
-    @contextmanager
-    def assert_stdout(self, expected_stdout):
-        with redirect_stdout(self.captured_stdout):
-            yield
-        self.assertEqual(self.captured_stdout.getvalue(), expected_stdout)
+    def run_testslide(
+        self,
+        tty_stdout=False,
+        expected_return_code=0,
+        expected_stdout=None,
+        expected_stdout_startswith=None,
+        expected_in_stdout=None,
+    ):
+        args = [
+            sys.executable,
+            "-m",
+            "testslide.cli",
+            "--show-testslide-stack-trace",
+        ] + self.argv
 
-    @contextmanager
-    def assert_in_stdout(self, expected_stdout):
-        with redirect_stdout(self.captured_stdout):
-            yield
-        self.assertTrue(
-            expected_stdout in self.captured_stdout.getvalue(),
-            "Expected:\n{}\nin stdout:\n{}".format(
-                expected_stdout, self.captured_stdout.getvalue()
-            ),
-        )
+        env = dict(copy.copy(os.environ))
+        env.update(self.env)
 
-    @contextmanager
-    def assert_in_stderr(self, expected_stderr):
-        with redirect_stderr(self.captured_stderr):
-            yield
-        self.assertTrue(
-            expected_stderr in self.captured_stderr.getvalue(),
-            "Expected:\n{}\nin stderr:\n{}".format(
-                expected_stderr, self.captured_stderr.getvalue()
-            ),
-        )
+        if tty_stdout:
+            stdout_master_fd, stdout_slave_fd = pty.openpty()
 
-    def execute(self, expected_return_value=0):
-        with patch.object(sys, "exit") as exit:
-            self.assertEqual(
-                cli.Cli(self.argv + [__file__]).run(), expected_return_value
+        encoding = sys.getdefaultencoding()
+
+        with subprocess.Popen(
+            args,
+            bufsize=1,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_slave_fd if tty_stdout else subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding=encoding,
+            env=env,
+            universal_newlines=True,
+        ) as popen:
+            stdout_chunks = []
+            stderr_chunks = []
+
+            def _process_output(fd, callback):
+                while True:
+                    try:
+                        chunk = os.read(fd, 8192)
+                    except OSError:
+                        break
+                    if len(chunk):
+                        callback(chunk)
+                    else:
+                        break
+
+            if tty_stdout:
+                stdout_fileno = stdout_master_fd
+            else:
+                stdout_fileno = popen.stdout.fileno()
+
+            process_stdout_thread = threading.Thread(
+                target=_process_output,
+                name="process_stdout",
+                args=(stdout_fileno, lambda line: stdout_chunks.append(line)),
             )
-            assert not exit.called
+            process_stdout_thread.start()
+
+            process_stderr_thread = threading.Thread(
+                target=_process_output,
+                name="process_stderr",
+                args=(popen.stderr.fileno(), lambda line: stderr_chunks.append(line)),
+            )
+            process_stderr_thread.start()
+
+            return_code = popen.wait()
+            if tty_stdout:
+                os.close(stdout_slave_fd)
+            process_stdout_thread.join()
+            process_stderr_thread.join()
+
+        stdout_output = "".join(chunk.decode(encoding) for chunk in stdout_chunks)
+        stderr_output = "".join(chunk.decode(encoding) for chunk in stderr_chunks)
+        output = ""
+        if stdout_output:
+            output += f"STDOUT:\n{stdout_output}\n"
+        if stderr_output:
+            output += f"STDERR:\n{stderr_output}\n"
+
+        self.assertEqual(
+            return_code,
+            expected_return_code,
+            f"Command {args} returned {return_code}, "
+            f"expected {expected_return_code}.\n{output}",
+        )
+        if expected_stdout:
+            self.assertEqual(
+                stdout_output,
+                expected_stdout,
+                f"Command {args} expected to have have this stdout:\n\n"
+                f"{expected_stdout}\n\n"
+                f"But output was different:\n"
+                f"{output}",
+            )
+        if expected_stdout_startswith:
+            self.assertTrue(
+                stdout_output.startswith(expected_stdout_startswith),
+                f"Command {args} expected to have have its stdout starting with:\n\n"
+                f"{expected_stdout_startswith}\n\n"
+                f"But output was different:\n"
+                f"{output}",
+            )
+        if expected_in_stdout:
+            self.assertTrue(
+                expected_in_stdout in stdout_output,
+                f"Command {args} expected to have have in its stdout:\n\n"
+                f"{expected_stdout_startswith}\n\n"
+                f"But output was different:\n"
+                f"{output}",
+            )
 
     @staticmethod
     def white(text):
@@ -127,110 +167,127 @@ class TestCliBase(unittest.TestCase):
 
 class TestCliList(TestCliBase):
     def setUp(self):
-        super(TestCliList, self).setUp()
-        self.argv.append("--list")
+        super().setUp()
+        self.argv.insert(0, "--list")
 
     def test_list(self):
         """
         With --list, print test names one per line.
         """
-        self.argv.append("--quiet")
-        with self.assert_in_stdout(
-            "top context: passing example\n"
-            "top context: failing example\n"
-            "top context: focused example\n"
-            "top context: skipped example\n"
-            "top context: unittest SkipTest\n"
-            "top context, nested context: passing nested example\n"
-        ):
-            self.execute()
+        self.run_testslide(
+            expected_stdout=(
+                "top context: passing example\n"
+                "top context: failing example\n"
+                "top context: focused example\n"
+                "top context: skipped example\n"
+                "top context: unittest SkipTest\n"
+                "top context, nested context: passing nested example\n"
+            )
+        )
 
 
 class TestCliQuiet(TestCliBase):
     def setUp(self):
-        super(TestCliQuiet, self).setUp()
-
-        @context
-        def quiet(context):
-            @context.example
-            def passing_verbose(self):
-                print("stdout text")
-                print("stderr text", file=sys.stderr)
-
-            @context.example
-            def failing_verbose(self):
-                print("stdout text")
-                print("stderr text", file=sys.stderr)
-                raise SimulatedFailure("test failure", "(extra)")
-
-            @context.example
-            def last_example(self):
-                pass
+        super().setUp()
+        self.env = {"PRINT": "True"}
 
     def test_with_quiet(self):
         """
         With --quiet, swallow both stderr and stdout unless the test fails.
         """
-        self.argv.append("--quiet")
-        with self.assert_in_stdout(
-            "quiet\n"
-            "  passing verbose: PASS\n"
-            "stdout:\n"
-            "stdout text\n"
-            "\n"
-            "stderr:\n"
-            "stderr text\n"
-            "\n"
-            "  failing verbose: SimulatedFailure: test failure (extra)\n"
-            "  last example: PASS\n"
-        ):
-            self.execute(expected_return_value=1)
+        self.argv.insert(0, "--quiet")
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  passing example: PASS\n"
+                "stdout:\n"
+                "failing_example stdout\n"
+                "\n"
+                "stderr:\n"
+                "failing_example stderr\n"
+                "\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "  *focused example: PASS\n"
+                "  skipped example: SKIP\n"
+                "  unittest SkipTest: SKIP\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Failures:\n"
+                # TODO Rest of the output
+            ),
+        )
 
     def test_without_quiet(self):
         """
         Without --quiet, allow test stdout and stderr to go on.
         """
-        stdout = (
-            "quiet\n"
-            "stdout text\n"
-            "  passing verbose: PASS\n"
-            "stdout text\n"
-            "  failing verbose: SimulatedFailure: test failure (extra)\n"
-            "  last example: PASS\n"
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "passing_example stdout\n"
+                "  passing example: PASS\n"
+                "failing_example stdout\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "focused_example stdout\n"
+                "  *focused example: PASS\n"
+                "  skipped example: SKIP\n"
+                "unittest_SkipTest stdout\n"
+                "  unittest SkipTest: SKIP\n"
+                "  nested context\n"
+                "passing_nested_example stdout\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Failures:\n"
+                # TODO Rest of the output
+            ),
         )
-        stderr = "stderr text\nstderr text\n"
-        with self.assert_in_stdout(stdout), self.assert_in_stderr(stderr):
-            self.execute(expected_return_value=1)
 
 
 class TestCliDocumentation(TestCliBase):
     def setUp(self):
-        TestCliBase.setUp(self)
-        self.argv.append("--format")
-        self.argv.append("documentation")
-        self.maxDiff = None
-        self.tb_shared_root = os.getcwd() + os.sep
-        self.tb_nested_path = "some/path/"
-        self.tb_prefix = "".join([self.tb_shared_root, self.tb_nested_path])
-        self.tb_list = [
-            ("{}one.py".format(self.tb_prefix), 42, "func1", "doSomething()"),
-            ("{}one/two.py".format(self.tb_prefix), 43, "func2", "doOther()"),
-        ]
-        self.tb_default_trimmed_list = [
-            ("{}one.py".format(self.tb_nested_path), 42, "func1", "doSomething()"),
-            ("{}one/two.py".format(self.tb_nested_path), 43, "func2", "doOther()"),
-        ]
-        self.tb_custom_trimmed_list = [
-            ("one.py", 42, "func1", "doSomething()"),
-            ("one/two.py", 43, "func2", "doOther()"),
-        ]
+        super().setUp()
+        self.argv = ["--format", "documentation"] + self.argv
 
     def test_colored_output_to_terminal(self):
         """
         Execute all examples in the order defined with colored output.
         """
-        with patch.object(self.captured_stdout, "isatty"):
-            with self.assert_in_stdout(
+        self.run_testslide(
+            tty_stdout=True,
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                self.white("top context")
+                + "\r\n"
+                + self.green("  passing example")
+                + "\r\n"
+                + self.red("  failing example: SimulatedFailure: test failure (extra)")
+                + "\r\n"
+                + self.green("  *focused example")
+                + "\r\n"
+                + self.yellow("  skipped example")
+                + "\r\n"
+                + self.yellow("  unittest SkipTest")
+                + "\r\n"
+                + self.white("  nested context")
+                + "\r\n"
+                + self.green("    passing nested example")
+                + "\r\n"
+                # TODO Rest of the output
+            ),
+        )
+
+    def test_colored_output_with_force_color(self):
+        """
+        Execute all examples in the order defined with colored output.
+        """
+        self.argv.append("--force-color")
+
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
                 self.white("top context")
                 + "\n"
                 + self.green("  passing example")
@@ -248,51 +305,29 @@ class TestCliDocumentation(TestCliBase):
                 + self.green("    passing nested example")
                 + "\n"
                 # TODO rest of output
-            ):
-                self.execute(expected_return_value=1)
-
-    def test_colored_output_with_force_color(self):
-        """
-        Execute all examples in the order defined with colored output.
-        """
-        self.argv.append("--force-color")
-        with self.assert_in_stdout(
-            self.white("top context")
-            + "\n"
-            + self.green("  passing example")
-            + "\n"
-            + self.red("  failing example: SimulatedFailure: test failure (extra)")
-            + "\n"
-            + self.green("  *focused example")
-            + "\n"
-            + self.yellow("  skipped example")
-            + "\n"
-            + self.yellow("  unittest SkipTest")
-            + "\n"
-            + self.white("  nested context")
-            + "\n"
-            + self.green("    passing nested example")
-            + "\n"
-            # TODO rest of output
-        ):
-            self.execute(expected_return_value=1)
+            ),
+        )
 
     def test_plain_output_without_terminal(self):
         """
         Execute all examples in the order defined without color.
         """
-        with self.assert_in_stdout(
-            "top context\n"
-            "  passing example: PASS\n"
-            "  failing example: SimulatedFailure: test failure (extra)\n"
-            "  *focused example: PASS\n"
-            "  skipped example: SKIP\n"
-            "  unittest SkipTest: SKIP\n"
-            "  nested context\n"
-            "    passing nested example: PASS\n"
-            # TODO rest of output
-        ):
-            self.execute(expected_return_value=1)
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  passing example: PASS\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "  *focused example: PASS\n"
+                "  skipped example: SKIP\n"
+                "  unittest SkipTest: SKIP\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Failures:\n"
+                # TODO rest of output
+            ),
+        )
 
     def test_shuffle(self):
         """
@@ -301,55 +336,74 @@ class TestCliDocumentation(TestCliBase):
         self.argv.append("--shuffle")
         self.argv.append("--seed")
         self.argv.append("33")
-        expected_stdout = "top context\n"
-        "  skipped example: SKIP\n"
-        "  passing example: PASS\n"
-        "  *focused example: PASS\n"
-        "  failing example: FAIL: SimulatedFailure: test failure (extra)\n"
-        "  nested context\n"
-        "    passing nested example: PASS\n\n"
-
-        with self.assert_in_stdout(
-            expected_stdout
-            # TODO rest of output
-        ):
-            self.execute(expected_return_value=1)
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  passing example: PASS\n"
+                "  *focused example: PASS\n"
+                "  skipped example: SKIP\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "  unittest SkipTest: SKIP\n"
+                "\n"
+                "Failures:\n"
+                # TODO rest of output
+            ),
+        )
 
     def test_focus(self):
         """
         Execute only focused examples.
         """
         self.argv.append("--focus")
-        with self.assert_in_stdout(
-            "top context\n"
-            "  *focused example: PASS\n\n"
-            # TODO rest of output
-        ):
-            self.execute()
+        self.run_testslide(
+            expected_stdout_startswith=(
+                "top context\n"
+                "  *focused example: PASS\n"
+                "\n"
+                "Finished 1 example(s) in "
+                # TODO rest of output
+            )
+        )
 
     def test_fail_if_focus(self):
         """
         Fail because there are focused tests and --fail-if-focused
         """
         self.argv.append("--fail-if-focused")
-        with self.assert_in_stdout(
-            "Focused example not allowed with --fail-if-focused."
-            " Please remove the focus to allow the test to run."
-        ):
-            self.execute(expected_return_value=1)
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  passing example: PASS\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "  *focused example: AssertionError: Focused example not allowed with --fail-if-focused. Please remove the focus to allow the test to run.\n"
+                "  skipped example: SKIP\n"
+                "  unittest SkipTest: SKIP\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Failures:\n"
+            ),
+        )
 
     def test_fail_fast(self):
         """
         Stop execution when first example fails.
         """
         self.argv.append("--fail-fast")
-        with self.assert_in_stdout(
-            "top context\n"
-            "  passing example: PASS\n"
-            "  failing example: SimulatedFailure: test failure (extra)\n\n"
-            # TODO rest of output
-        ):
-            self.execute(expected_return_value=1)
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  passing example: PASS\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "\n"
+                "Failures:\n"
+            ),
+        )
 
     def test_text_filter(self):
         """
@@ -357,13 +411,17 @@ class TestCliDocumentation(TestCliBase):
         """
         self.argv.append("--filter-text")
         self.argv.append("nested context: passing nested ex")
-        with self.assert_in_stdout(
-            "top context\n"
-            "  nested context\n"
-            "    passing nested example: PASS\n\n"
-            # TODO rest of output
-        ):
-            self.execute()
+
+        self.run_testslide(
+            expected_return_code=0,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Finished 1 example(s) in "
+            ),
+        )
 
     def test_regexp_filter(self):
         """
@@ -371,13 +429,16 @@ class TestCliDocumentation(TestCliBase):
         """
         self.argv.append("--filter-regex")
         self.argv.append(".*passing nested.*")
-        with self.assert_in_stdout(
-            "top context\n"
-            "  nested context\n"
-            "    passing nested example: PASS\n\n"
-            # TODO rest of output
-        ):
-            self.execute()
+        self.run_testslide(
+            expected_return_code=0,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Finished 1 example(s) in "
+            ),
+        )
 
     def test_exclude_regexp(self):
         """
@@ -385,50 +446,43 @@ class TestCliDocumentation(TestCliBase):
         """
         self.argv.append("--exclude-regex")
         self.argv.append(".*failing.*")
-        with self.assert_in_stdout(
-            "top context\n"
-            "  passing example: PASS\n"
-            "  *focused example: PASS\n"
-            "  skipped example: SKIP\n"
-            "  unittest SkipTest: SKIP\n"
-            "  nested context\n"
-            "    passing nested example: PASS\n\n"
-            # TODO rest of output
-        ):
-            self.execute()
+        self.run_testslide(
+            expected_return_code=0,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  passing example: PASS\n"
+                "  *focused example: PASS\n"
+                "  skipped example: SKIP\n"
+                "  unittest SkipTest: SKIP\n"
+                "  nested context\n"
+                "    passing nested example: PASS\n"
+                "\n"
+                "Finished 5 example(s) in "
+            ),
+        )
 
     def test_default_trim_stack_trace_path_prefix(self):
         """
         Default value for --trim-stack-trace-path-prefix trims path shared with
         testslide itself.
         """
-        with patch.object(traceback, "extract_tb", return_value=self.tb_list):
-            with self.assert_in_stdout(
-                "".join(
-                    '      File "{}", line {}, in {}\n        {}\n'.format(
-                        path, line, func, code
-                    )
-                    for path, line, func, code in self.tb_default_trimmed_list
-                )
-            ):
-                self.execute(expected_return_value=1)
+        self.run_testslide(
+            expected_return_code=1,
+            expected_in_stdout=('File "tests/sample_dsl.py", line'),
+        )
 
     def test_nonempty_trim_stack_trace_path_prefix(self):
         """
         Trims prefix passed to --trim-stack-trace-path-prefix.
         """
         self.argv.append("--trim-stack-trace-path-prefix")
-        self.argv.append(self.tb_prefix)
-        with patch.object(traceback, "extract_tb", return_value=self.tb_list):
-            with self.assert_in_stdout(
-                "".join(
-                    '      File "{}", line {}, in {}\n        {}\n'.format(
-                        path, line, func, code
-                    )
-                    for path, line, func, code in self.tb_custom_trimmed_list
-                )
-            ):
-                self.execute(expected_return_value=1)
+        self.argv.append(os.path.dirname(self.SAMPLE_DSL_PATH) + "/")
+        self.run_testslide(
+            expected_return_code=1,
+            expected_in_stdout=(
+                'File "' + os.path.basename(self.SAMPLE_DSL_PATH) + '", line'
+            ),
+        )
 
     def test_empty_trim_strace_path_prefix(self):
         """
@@ -436,37 +490,32 @@ class TestCliDocumentation(TestCliBase):
         """
         self.argv.append("--trim-stack-trace-path-prefix")
         self.argv.append("")
-        with patch.object(traceback, "extract_tb", return_value=self.tb_list):
-            with self.assert_in_stdout(
-                "".join(
-                    '      File "{}", line {}, in {}\n        {}\n'.format(
-                        path, line, func, code
-                    )
-                    for path, line, func, code in self.tb_list
-                )
-            ):
-                self.execute(expected_return_value=1)
+        self.run_testslide(
+            expected_return_code=1,
+            expected_in_stdout=('File "' + self.SAMPLE_DSL_PATH + '", line'),
+        )
 
 
 class TestCliProgress(TestCliBase):
     def setUp(self):
-        TestCliBase.setUp(self)
+        super().setUp()
         self.argv.append("--format")
         self.argv.append("progress")
 
     def test_ouputs_dots(self):
-        with self.assert_stdout(".F.SS.\n"):
-            self.execute(expected_return_value=1)
+        self.run_testslide(expected_return_code=1, expected_stdout=(".F.SS.\n"))
 
     def test_ouputs_colored_dots_with_terminal(self):
-        with patch.object(self.captured_stdout, "isatty"):
-            with self.assert_stdout(
+        self.run_testslide(
+            tty_stdout=True,
+            expected_return_code=1,
+            expected_stdout=(
                 self.green(".")
                 + self.red("F")
                 + self.green(".")
                 + self.yellow("S")
                 + self.yellow("S")
                 + self.green(".")
-                + "\n"
-            ):
-                self.execute(expected_return_value=1)
+                + "\r\n"
+            ),
+        )

--- a/tests/sample_dsl.py
+++ b/tests/sample_dsl.py
@@ -1,0 +1,55 @@
+from testslide.dsl import context
+import unittest
+import os
+import sys
+
+
+class SimulatedFailure(Exception):
+    def __init__(self, message, second_message):
+        """
+        This method purposely accepts an extra argument to catch failures when
+        reraising exceptions.
+        """
+        super(SimulatedFailure, self).__init__(message, second_message)
+        self.message = message
+        self.second_message = second_message
+
+    def __str__(self):
+        return "{} {}".format(self.message, self.second_message)
+
+
+def _cond_print(name):
+    if "PRINT" in os.environ:
+        print(f"{name} stdout")
+        print(f"{name} stderr", file=sys.stderr)
+
+
+@context
+def top_context(context):
+    @context.example
+    def passing_example(self):
+        _cond_print("passing_example")
+
+    @context.example
+    def failing_example(self):
+        _cond_print("failing_example")
+        raise SimulatedFailure("test failure", "(extra)")
+
+    @context.fexample
+    def focused_example(self):
+        _cond_print("focused_example")
+
+    @context.xexample
+    def skipped_example(self):
+        _cond_print("skipped_example")
+
+    @context.example
+    def unittest_SkipTest(self):
+        _cond_print("unittest_SkipTest")
+        raise unittest.SkipTest("Skipped with unittest.SkipTest")
+
+    @context.sub_context
+    def nested_context(context):
+        @context.example
+        def passing_nested_example(self):
+            _cond_print("passing_nested_example")


### PR DESCRIPTION
The CLI tests were executing the CLI interface on the same process, thus running not only the sample tests, but all tests declared on the same file. This is creating problems when implementing async support, as the test runner is running another test runner inside itself: an event loop inside an event loop.

This diff refactor the tests:

- All sample tests were moved to `sample_dsl.py`.
- All CLI tests now spawn an independent Python process and captures its output.
- Assertions were tightened a bit to ensure only the expected tests are in fact executed.