### PR TITLE
Drop before_once

### DIFF
--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -8,7 +8,7 @@ import unittest
 from unittest.mock import Mock, call, patch
 
 from testslide import Context, AggregatedExceptions, reset
-from testslide.dsl import context, xcontext, fcontext, before_once
+from testslide.dsl import context, xcontext, fcontext
 import os
 import subprocess
 
@@ -1099,96 +1099,6 @@ class TestDSLBeforeHook(TestDSLBase):
             @context.before
             def not_allowed(self):
                 pass
-
-
-class TestDSLBeforeOnceHook(TestDSLBase):
-    def test_execution_order(self):
-        """
-        Before once hooks must be called only one time before all examples.
-        """
-        mock = Mock()
-
-        @before_once
-        def first_before_once():
-            mock("first_before_once")
-
-        @before_once
-        def second_before_once():
-            mock("second_before_once")
-
-        @context
-        def top(context):
-            @context.before
-            def before_hook(self):
-                mock("before_hook")
-
-            @context.example
-            def first_example(self):
-                mock("first_example")
-
-            @context.example
-            def second_example(self):
-                mock("second_example")
-
-        self.run_first_context_all_examples()
-        self.assertEqual(
-            mock.mock_calls,
-            [
-                call("first_before_once"),
-                call("second_before_once"),
-                call("before_hook"),
-                call("first_example"),
-                call("before_hook"),
-                call("second_example"),
-            ],
-        )
-
-    def test_before_once_as_lambda(self):
-        """
-        Before one can accept lambdas.
-        """
-        mock = Mock()
-
-        before_once(lambda: mock("before_once"))
-
-        @context
-        def top(context):
-            @context.before
-            def before_hook(self):
-                mock("before_hook")
-
-            @context.example
-            def example(self):
-                mock("example")
-
-        self.run_first_context_all_examples()
-        self.assertEqual(
-            mock.mock_calls, [call("before_once"), call("before_hook"), call("example")]
-        )
-
-    def test_before_once_failure(self):
-        """
-        Stop execution if before once hook fails.
-        """
-        mock = Mock()
-
-        @before_once
-        def first_before_once_fail():
-            raise RuntimeError("first_before_once_fail")
-
-        before_once(lambda: mock("second_before_hook_does_not_run"))
-
-        @context
-        def top(context):
-            @context.example
-            def with_before_hook(self):
-                mock("example")
-
-        try:
-            self.run_first_context_first_example()
-        except RuntimeError:
-            pass
-        self.assertEqual(mock.mock_calls, [])
 
 
 class TestDSLAfterHook(TestDSLBase):

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -223,8 +223,6 @@ class Example(object):
         if around_functions is None:
             around_functions = list(reversed(self.context.all_around_functions))
 
-        _run_before_once_hooks()
-
         if not around_functions:
             self._example_runner(context_data)
             return
@@ -633,28 +631,11 @@ class Context(object):
         self.around_functions.append(wrap_test_case)
 
 
-before_once_functions = []
-before_once_executed = False
-
-
-def _run_before_once_hooks():
-    global before_once_executed
-    if not before_once_executed:
-        global before_once_functions
-        for code in before_once_functions:
-            code()
-    before_once_executed = True
-
-
 def reset():
     """
     Clear all defined contexts and hooks.
     """
     Context.all_top_level_contexts.clear()
-    global before_once_functions
-    before_once_functions.clear()
-    global before_once_executed
-    before_once_executed = False
 
 
 class TestCase(unittest.TestCase):

--- a/testslide/dsl.py
+++ b/testslide/dsl.py
@@ -7,8 +7,6 @@ import functools
 from re import sub as _sub
 
 from . import Context as _Context
-from . import before_once_functions as _before_once_functions  # noqa: F401
-
 from . import Skip  # noqa: F401
 
 
@@ -218,7 +216,3 @@ context = _DSLContext()
 xcontext = _DSLContext(skip=True)
 
 fcontext = _DSLContext(focus=True)
-
-
-def before_once(code):
-    _before_once_functions.append(code)


### PR DESCRIPTION
This undocumented feature has virtually no use and is implemented in a hacky way.

Closes #61 .