### PR TITLE
Refactor strict mock

### DIFF
--- a/docs/strict_mock/index.rst
+++ b/docs/strict_mock/index.rst
@@ -34,20 +34,20 @@ StrictMock is **safe by default**: it only has configure behavior:
 
 .. code-block:: ipython
 
-  In [1]: from testslide import StrictMock
+  In [1]: from testslide import StrictMock                                                      
   
-  In [2]: class Calculator:
-     ...:   def is_odd(self, x):
-     ...:     return bool(x % 2)
-     ...:   
+  In [2]: class Calculator: 
+     ...:     def is_odd(self, x): 
+     ...:         return bool(x % 2) 
+     ...:                                                                                       
   
-  In [3]: mock = StrictMock(Calculator)
+  In [3]: mock = StrictMock(template=Calculator)                                                
   
-  In [4]: mock.is_odd(2)
+  In [4]: mock.is_odd(2)                                                                        
   (...)
-  UndefinedBehavior: <StrictMock 0x7F290A3DD860 template=__main__.Calculator>:
-    Attribute 'is_odd' has no behavior defined.
-    You can define behavior by assigning a value to it.
+  UndefinedAttribute: 'is_odd' is not defined.
+  <StrictMock 0x7F17E06C7310 template=__main__.Calculator> must have a value defined for this attribute if it is going to be accessed.
+
 
 Instead of guessing what ``is_odd`` should return, StrictMock clearly tells you it was not told what to do with it. In this case, the mock is clearly missing the behavior, that we can trivially add:
 
@@ -70,20 +70,20 @@ You won't be allowed to set an attribute to a StrictMock if the given template c
 
 .. code-block:: ipython
 
-  In [1]: from testslide import StrictMock
+  In [1]: from testslide import StrictMock                                                      
   
-  In [2]: class Calculator:
-     ...:   def is_odd(self, x):
-     ...:     return bool(x % 2)
-     ...:   
+  In [2]: class Calculator: 
+     ...:   def is_odd(self, x): 
+     ...:     return bool(x % 2) 
+     ...:                                                                                       
   
-  In [3]: mock = StrictMock(Calculator)
+  In [3]: mock = StrictMock(template=Calculator)                                                
   
-  In [4]: mock.invalid = 'whatever'
+  In [4]: mock.invalid = "whatever"                                                             
   (...)
-  NoSuchAttribute: <StrictMock 0x7F7821920780 template=__main__.Calculator>:
-    No such attribute 'invalid'.
-    Can not set attribute invalid that is neither part of template class Calculator or runtime_attrs=[].
+  CanNotSetNonExistentAttribute: 'invalid' can not be set.
+  <StrictMock 0x7F4C62423F10 template=__main__.Calculator> template class does not have this attribute so the mock can not have it as well.
+  See also: 'runtime_attrs' at StrictMock.__init__.
 
 Dynamic Attributes
 """"""""""""""""""
@@ -176,9 +176,8 @@ It is recommended to use StrictMock giving it a template class, so you can lever
   
   In [3]: mock.whatever
   (...)
-  UndefinedBehavior: <StrictMock 0x7FED1C724C18>:
-    Attribute 'whatever' has no behavior defined.
-    You can define behavior by assigning a value to it.
+  UndefinedAttribute: 'whatever' is not defined.
+  <StrictMock 0x7FED1C724C18> must have a value defined for this attribute if it is going to be accessed.
   
   In [4]: mock.whatever = 'something'
   

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -3,7 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from testslide.strict_mock import StrictMock, UndefinedBehavior, NoSuchAttribute
+from testslide.strict_mock import (
+    StrictMock,
+    UndefinedAttribute,
+    NonExistentAttribute,
+    NonCallableValue,
+)
 
 import contextlib
 import copy
@@ -127,16 +132,11 @@ def strict_mock(context):
 
             @context.example
             def raises_when_an_undefined_attribute_is_accessed(self):
-                attr_name = "undefined_attribute"
+                name = "undefined_attribute"
                 with self.assertRaisesWithRegexMessage(
-                    UndefinedBehavior,
-                    "{}:\n  ".format(self.strict_mock_rgx)
-                    + re.escape(
-                        "Attribute '{}' has no behavior defined.\n  ".format(attr_name)
-                    )
-                    + "You can define behavior by assigning a value to it.",
+                    AttributeError, f"'{name}' was not set for {self.strict_mock}."
                 ):
-                    getattr(self.strict_mock, attr_name)
+                    getattr(self.strict_mock, name)
 
             @context.example
             def allows_mocking_any_attribute(self):
@@ -150,10 +150,7 @@ def strict_mock(context):
                 self.assertTrue(hasattr(self.strict_mock, name))
                 delattr(self.strict_mock, name)
                 with self.assertRaisesWithRegexMessage(
-                    UndefinedBehavior,
-                    "{}:\n  ".format(self.strict_mock_rgx)
-                    + "Attribute '{}' has no behavior defined.\n  ".format(name)
-                    + "You can define behavior by assigning a value to it.",
+                    AttributeError, f"'{name}' was not set for {self.strict_mock}."
                 ):
                     getattr(self.strict_mock, name)
 
@@ -186,12 +183,10 @@ def strict_mock(context):
                 def raises_when_an_undefined_attribute_is_accessed(self):
                     attr_name = "non_callable"
                     with self.assertRaisesWithRegexMessage(
-                        UndefinedBehavior,
-                        "{}:\n  ".format(self.strict_mock_rgx)
-                        + "Attribute '{}' has no behavior defined.\n  ".format(
-                            attr_name
-                        )
-                        + "You can define behavior by assigning a value to it.",
+                        UndefinedAttribute,
+                        f"'{attr_name}' is not set.\n"
+                        f"{self.strict_mock_rgx} must have a value set "
+                        "for this attribute if it is going to be accessed.",
                     ):
                         getattr(self.strict_mock, attr_name)
 
@@ -200,14 +195,7 @@ def strict_mock(context):
                     attr_name = "non_existing_attr"
                     with self.assertRaisesWithRegexMessage(
                         AttributeError,
-                        "{}: ".format(self.strict_mock_rgx)
-                        + re.escape(
-                            "Can not getattr() an attribute '{}' ".format(attr_name)
-                        )
-                        + "that is neither part of template class Template or "
-                        + re.escape(
-                            "runtime_attrs=[{}].".format(repr(self.runtime_attr))
-                        ),
+                        f"'{attr_name}' was not set for {self.strict_mock_rgx}.",
                     ):
                         getattr(self.strict_mock, attr_name)
 
@@ -215,15 +203,11 @@ def strict_mock(context):
                 def raises_when_setting_non_existing_attributes(self):
                     attr_name = "non_existing_attr"
                     with self.assertRaisesWithRegexMessage(
-                        NoSuchAttribute,
-                        "{}:\n  ".format(self.strict_mock_rgx)
-                        + "No such attribute '{}'.\n  ".format(attr_name)
-                        + "Can not set attribute non_existing_attr that is neither "
-                        + re.escape(
-                            "part of template class Template or runtime_attrs=[{}].".format(
-                                repr(self.runtime_attr)
-                            )
-                        ),
+                        NonExistentAttribute,
+                        f"'{attr_name}' can not be set.\n"
+                        f"{self.strict_mock_rgx} template class does not have "
+                        "this attribute so the mock can not have it as well.\n"
+                        "See also: 'runtime_attrs' at StrictMock.__init__.",
                     ):
                         setattr(self.strict_mock, attr_name, "whatever")
 
@@ -267,14 +251,12 @@ def strict_mock(context):
                 def failures(context):
                     @context.example
                     def raises_when_setting_a_non_callable_value(self):
-                        non_callable = "non callable"
                         with self.assertRaisesWithRegexMessage(
-                            ValueError,
-                            "{}: ".format(self.strict_mock_rgx)
-                            + "Template class attribute '{}' attribute is ".format(
-                                self.test_method_name
-                            )
-                            + "callable and {} is not.".format(repr(non_callable)),
+                            NonCallableValue,
+                            f"'{self.test_method_name}' can not be set with a "
+                            "non-callable value.\n"
+                            f"{self.strict_mock_rgx} template class requires "
+                            "this attribute to be callable.",
                         ):
                             setattr(
                                 self.strict_mock, self.test_method_name, "non callable"
@@ -283,12 +265,10 @@ def strict_mock(context):
                     @context.example
                     def raises_when_an_undefined_method_is_accessed(self):
                         with self.assertRaisesWithRegexMessage(
-                            UndefinedBehavior,
-                            "{}:\n  ".format(self.strict_mock_rgx)
-                            + "Attribute '{}' has no behavior defined.\n  ".format(
-                                self.test_method_name
-                            )
-                            + "You can define behavior by assigning a value to it.",
+                            UndefinedAttribute,
+                            f"'{self.test_method_name}' is not set.\n"
+                            f"{self.strict_mock_rgx} must have a value set "
+                            "for this attribute if it is going to be accessed.",
                         ):
                             getattr(self.strict_mock, self.test_method_name)
 
@@ -297,14 +277,8 @@ def strict_mock(context):
                         attr_name = "non_existing_method"
                         with self.assertRaisesWithRegexMessage(
                             AttributeError,
-                            "{}: ".format(self.strict_mock_rgx)
-                            + re.escape(
-                                "Can not getattr() an attribute '{}' ".format(attr_name)
-                            )
-                            + "that is neither part of template class Template or "
-                            + re.escape(
-                                "runtime_attrs=['{}'].".format(self.runtime_attr)
-                            ),
+                            f"'{attr_name}' was not set for "
+                            f"{self.strict_mock_rgx}.",
                         ):
                             getattr(self.strict_mock, attr_name)
 
@@ -312,17 +286,12 @@ def strict_mock(context):
                     def raises_when_setting_non_existing_methods(self):
                         attr_name = "non_existing_method"
                         with self.assertRaisesWithRegexMessage(
-                            NoSuchAttribute,
-                            "{}:\n  ".format(self.strict_mock_rgx)
-                            + "No such attribute '{}'.\n  ".format(attr_name)
-                            + "Can not set attribute {} that is neither part of ".format(
-                                attr_name
-                            )
-                            + re.escape(
-                                "template class Template or runtime_attrs=['{}'].".format(
-                                    self.runtime_attr
-                                )
-                            ),
+                            NonExistentAttribute,
+                            f"'{attr_name}' can not be set.\n"
+                            f"{self.strict_mock_rgx} template class does not "
+                            "have this attribute so the mock can not have it "
+                            "as well.\n"
+                            "See also: 'runtime_attrs' at StrictMock.__init__.",
                         ):
                             self.strict_mock.non_existing_method = self.mock_function
 
@@ -397,36 +366,6 @@ def strict_mock(context):
                                 SomeClass().mock_method,
                             )
 
-                        @context.example
-                        def can_access_attributes(self):
-                            self.mock_function.attribute = "value"
-                            setattr(
-                                self.strict_mock,
-                                self.test_method_name,
-                                self.mock_function,
-                            )
-                            mocked_metod = getattr(
-                                self.strict_mock, self.test_method_name
-                            )
-                            self.assertEqual(
-                                getattr(mocked_metod, "attribute"), "value"
-                            )
-                            setattr(mocked_metod, "new_attribute", "new_value")
-                            self.assertEqual(
-                                getattr(mocked_metod, "new_attribute"), "new_value"
-                            )
-                            delattr(mocked_metod, "new_attribute")
-                            self.assertFalse(hasattr(mocked_metod, "new_attribute"))
-
-                    @context.sub_context
-                    def when_template_has_context_manager_methods(context):
-                        @context.example
-                        def context_management_mocked_by_default(self):
-                            with self.context_manager_strict_mock as target:
-                                self.assertTrue(
-                                    target is self.context_manager_strict_mock
-                                )
-
             @context.shared_context
             def instance_attributes(context):
 
@@ -458,6 +397,41 @@ def strict_mock(context):
 
                         context.merge_context("callable attributes")
 
+                    @context.sub_context
+                    def context_manager(context):
+                        @context.sub_context("with default_context_manager=True")
+                        def with_default_context_manager_True(context):
+                            @context.memoize
+                            def context_manager_strict_mock(self):
+                                return StrictMock(template=ContextManagerTemplate)
+
+                            @context.example
+                            def context_manager_works(self):
+                                with self.context_manager_strict_mock as target:
+                                    self.assertTrue(
+                                        target is self.context_manager_strict_mock
+                                    )
+
+                        @context.sub_context("with default_context_manager=False")
+                        def with_default_context_manager_False(context):
+                            @context.memoize
+                            def context_manager_strict_mock(self):
+                                return StrictMock(
+                                    template=ContextManagerTemplate,
+                                    default_context_manager=False,
+                                )
+
+                            @context.xexample
+                            def context_manager_raises_UndefinedAttribute(self):
+                                with self.assertRaisesWithRegexMessage(
+                                    UndefinedAttribute,
+                                    f"'__enter__' is not set.\n"
+                                    f"{self.strict_mock_rgx} must have a value set "
+                                    "for this attribute if it is going to be accessed.",
+                                ):
+                                    with self.context_manager_strict_mock:
+                                        pass
+
             @context.sub_context
             def mock_instance_after_a_class_as_template(context):
                 @context.before
@@ -472,9 +446,6 @@ def strict_mock(context):
                         )
                         + re.escape(self.caller_filename)
                         + ":\d+>"
-                    )
-                    self.context_manager_strict_mock = StrictMock(
-                        ContextManagerTemplate
                     )
 
                     def mock_function(message):

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -39,6 +39,9 @@ class TemplateParent(object):
     def __abs__(self):
         return 33
 
+    def __len__(self):
+        return 2341
+
 
 class Template(TemplateParent):
 
@@ -414,10 +417,23 @@ def strict_mock(context):
                                 abs(self.strict_mock)
 
                         @context.example
-                        def can_define_magic_methods(self):
+                        def can_set_magic_methods(self):
                             value = 23412
                             self.strict_mock.__abs__ = lambda: value
                             self.assertEqual(abs(self.strict_mock), value)
+
+                        @context.example("bool() works")
+                        def bool_works(self):
+                            with self.assertRaisesWithRegexMessage(
+                                UndefinedAttribute,
+                                f"'__len__' is not set.\n"
+                                f"{self.strict_mock_rgx} must have a value set "
+                                "for this attribute if it is going to be accessed.",
+                            ):
+                                bool(self.strict_mock)
+
+                            self.strict_mock.__len__ = lambda: 0
+                            self.assertEqual(bool(self.strict_mock), False)
 
                         @context.sub_context
                         def context_manager(context):

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -414,7 +414,9 @@ class StrictMock(object):
 
     def __setattr__(self, name, value):
         if name.startswith("__") and name.endswith("__"):
-            if name in self._UNSETTABLE_MAGICS or name in StrictMock.__dict__:
+            if name in self._UNSETTABLE_MAGICS or (
+                name in StrictMock.__dict__ and name not in self._SETTABLE_MAGICS
+            ):
                 raise UnsupportedMagic(self, name)
             if name not in self._SETTABLE_MAGICS:
                 raise NotImplementedError(


### PR DESCRIPTION
Refactor StrictMock to address issues with magic methods (see #23).

The mechanic after this diff is:

- Create a subclass of StrictMock.
- Populate this subclass with all existing magic methods from the template class.
- Setting any attributes will set them at the subclass.
- There's validation for valid and invalid magic methods (previously missing).

Closes #23 .