### PR TITLE
Add async support for DSL

### DIFF
--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -1,12 +1,15 @@
 Async Support
 =============
 
-TestSlide's DSL supports `asynchronous I/O <https://docs.python.org/3/library/asyncio.html>`_ testing. For that you must:
+TestSlide's DSL supports `asynchronous I/O <https://docs.python.org/3/library/asyncio.html>`_ testing.
 
-- Declare contexts as sync functions as usual.
-- Declare examples and hooks (around, before and after) as async.
+For that, you must declare all of these as async:
 
-Example:
+- Hooks: around, before and after.
+- Examples.
+- Memoize before.
+
+like this:
 
 .. code-block:: python
 
@@ -17,21 +20,29 @@ Example:
     @context.around
     async def around(self, example):
       await example()  # Note that this must be awaited!
-
+  
     @context.before
     async def before(self):
       pass
-
+  
     @context.after
     async def after(self):
       pass
-
+  
+    @context.memoize_before
+    async def memoize_before(self):
+      return "memoize_before"
+  
     @context.example
     async def example(self):
-      pass
+      assert self.memoize_before == "memoize_before"
 
-The test runner will create a new event look to execute each example with all its hooks.
+The test runner will create a new event look to execute each example.
 
 .. note::
 
-  You can **not** mix async and sync examples and functions. If your example is sync, all its hooks must be sync; if the example is async, all its hooks must be async.
+  You can **not** mix async and sync stuff for the same example. If your example is async, then all its hooks and memoize before must also be async.
+
+.. note::
+
+  It is not possible to support async ``@context.memoize``. They depend on `__getattr__ <https://docs.python.org/3/reference/datamodel.html#object.__getattr__>`_ to work, which has no async support. Use ``@context.memoize_before`` instead.

--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -8,6 +8,7 @@ For that, you must declare all of these as async:
 - Hooks: around, before and after.
 - Examples.
 - Memoize before.
+- Functions.
 
 like this:
 
@@ -32,10 +33,15 @@ like this:
     @context.memoize_before
     async def memoize_before(self):
       return "memoize_before"
+
+    @context.function
+    async def function(self):
+      return "function"
   
     @context.example
     async def example(self):
       assert self.memoize_before == "memoize_before"
+      assert self.function == "function"
 
 The test runner will create a new event look to execute each example.
 

--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -1,0 +1,37 @@
+Async Support
+=============
+
+TestSlide's DSL supports `asynchronous I/O <https://docs.python.org/3/library/asyncio.html>`_ testing. For that you must:
+
+- Declare contexts as sync functions as usual.
+- Declare examples and hooks (around, before and after) as async.
+
+Example:
+
+.. code-block:: python
+
+  from testslide.dsl import context
+  
+  @context
+  def testing_async_code(context):
+    @context.around
+    async def around(self, example):
+      await example()  # Note that this must be awaited!
+
+    @context.before
+    async def before(self):
+      pass
+
+    @context.after
+    async def after(self):
+      pass
+
+    @context.example
+    async def example(self):
+      pass
+
+The test runner will create a new event look to execute each example with all its hooks.
+
+.. note::
+
+  You can **not** mix async and sync examples and functions. If your example is sync, all its hooks must be sync; if the example is async, all its hooks must be async.

--- a/docs/testslide_dsl/index.rst
+++ b/docs/testslide_dsl/index.rst
@@ -83,3 +83,4 @@ As the ``Backup`` class grows, it is easy to nest new contexts, and reuse what's
    context_attributes_and_functions/index.rst
    skip_and_focus/index.rst
    unittest_testcase_integration/index.rst
+   async_support/index.rst

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -1714,6 +1714,10 @@ class SmokeTestAsync(TestDSLBase):
             async def second_after(self):
                 order.append("second_after")
 
+            @context.function
+            async def function(self):
+                return "function"
+
             @context.example
             async def example(self):
                 @self.after
@@ -1724,6 +1728,7 @@ class SmokeTestAsync(TestDSLBase):
                 async def example_second_after(self):
                     order.append("example_second_after")
 
+                assert "function" == await self.function()
                 order.append("example")
 
         self.run_first_context_first_example()

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -1687,26 +1687,61 @@ class SmokeTestAsync(TestDSLBase):
         @context
         def top(context):
             @context.around
-            async def around(self, wrapped):
-                order.append("around before")
+            async def first_around(self, wrapped):
+                order.append("first_around before")
                 await wrapped()
-                order.append("around after")
+                order.append("first_around after")
+
+            @context.around
+            async def second_around(self, wrapped):
+                order.append("second_around before")
+                await wrapped()
+                order.append("second_around after")
 
             @context.before
-            async def before(self):
-                order.append("before")
+            async def first_before(self):
+                order.append("first_before")
+
+            @context.before
+            async def second_before(self):
+                order.append("second_before")
 
             @context.after
-            async def after(self):
-                order.append("after")
+            async def first_after(self):
+                order.append("first_after")
+
+            @context.after
+            async def second_after(self):
+                order.append("second_after")
 
             @context.example
             async def example(self):
+                @self.after
+                async def example_first_after(self):
+                    order.append("example_first_after")
+
+                @self.after
+                async def example_second_after(self):
+                    order.append("example_second_after")
+
                 order.append("example")
 
         self.run_first_context_first_example()
         self.assertEqual(
-            order, ["around before", "before", "example", "after", "around after"]
+            order,
+            [
+                "first_around before",
+                "second_around before",
+                "first_before",
+                "second_before",
+                "example",
+                "example_second_after",
+                "example_first_after",
+                "second_after",
+                "first_after",
+                "second_around after",
+                "first_around after",
+            ],
         )
 
     def test_can_not_mix_async_hooks_with_sync_example(self):

--- a/tests/testcase_unittest.py
+++ b/tests/testcase_unittest.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import csv
 import testslide
 import unittest
-import logging
 
 
 class Dummy(object):
@@ -25,8 +25,9 @@ class TestSlideTestCaseIntegration(testslide.TestCase):
         self.assertEqual(dummy.do_something(), 42)
 
     def test_has_mock_constructor(self):
-        logger = testslide.StrictMock(logging.Logger)
-        self.mock_constructor(logging, "Logger").for_call(level=0).to_return_value(
-            logger
+        dict_reader = testslide.StrictMock(csv.DictReader)
+        path = "/meh"
+        self.mock_constructor(csv, "DictReader").for_call(path).to_return_value(
+            dict_reader
         )
-        self.assertTrue(id(logger), id(logging.Logger(level=0)))
+        self.assertTrue(id(dict_reader), id(csv.DictReader(path)))

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -104,7 +104,12 @@ class _ContextData(object):
             self.__dict__[name] = static
 
         if name in self._all_attributes.keys():
-            self.__dict__[name] = self._all_attributes[name](self)
+            attribute_code = self._all_attributes[name]
+            if self._example.is_async and inspect.iscoroutinefunction(attribute_code):
+                raise ValueError(
+                    f"Function can not be a coroutine function: {repr(attribute_code)}"
+                )
+            self.__dict__[name] = attribute_code(self)
 
         try:
             return self.__dict__[name]


### PR DESCRIPTION
Add support for [TestSlide's DSL](https://testslide.readthedocs.io/en/1.7.0/testslide_dsl/index.html) to test async stuff.

Example usage:

```python
from testslide.dsl import context

@context
def testing_async_code(context):
  @context.around
  async def around(self, example):
    await example()  # Note that this must be awaited!

  @context.before
  async def before(self):
    pass

  @context.after
  async def after(self):
    pass

  @context.memoize_before
  async def memoize_before(self):
    return "memoize_before"

  @context.function
  async def function(self):
    return "function"

  @context.example
  async def example(self):
    assert self.memoize_before == "memoize_before"
    assert self.function == "function"
```

There's some ugliness at `_ExampleRunner`: `def _sync_run_all_hooks_and_example` and `async def _real_async_run_all_hooks_and_example` implement the exact same thing, one being sync the other async. I left big warnings at both to keep them in sync. Unfortunately I found no better way of sharing logic between sync and async code. I added a smoke test for the async version of the function, that should cover most of the ground to mitigate that.

Closes of #57 .

PS: Reissue of #59.