### PR TITLE
Reorganize mock_callable() tests

### DIFF
--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -1,0 +1,8 @@
+def test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+    "This function is used by some unit tests only"
+    return "original response"
+
+
+async def async_test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+    "This function is used by some unit tests only"
+    return "original response"

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -808,8 +808,3 @@ class TestCase(unittest.TestCase):
     @staticmethod
     def mock_constructor(target, class_name):
         return testslide.mock_constructor.mock_constructor(target, class_name)
-
-
-def _test_function(arg1, arg2, kwarg1=None, kwarg2=None):
-    "This function is used by some unit tests only"
-    return "original response"


### PR DESCRIPTION
Keep the same test coverage, but re-organize them in a more manageable fashion.

Travis CI output shows the final organization, but the TLDR now is:

- Target type (eg: module, class, instance...)
  - Callable type (function, instance/class/static method).
    - Special cases