### PR TITLE
Add tests for rejecting async targets

### DIFF
--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -6,6 +6,7 @@
 import sys
 import asyncio
 import unittest
+import time
 
 from unittest.mock import Mock, call, patch
 
@@ -1849,6 +1850,16 @@ class SmokeTestAsync(TestDSLBase):
             with self.assertRaisesRegex(
                 RuntimeWarning, "coroutine '.+' was never awaited"
             ):
+                self.run_first_context_first_example()
+
+        def test_fail_if_slow_task(self):
+            @context
+            def top(context):
+                @context.example
+                async def example(self):
+                    time.sleep(0.1)
+
+            with self.assertRaisesRegex(RuntimeError, "^Executing .+ took .+ seconds$"):
                 self.run_first_context_first_example()
 
 

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -1,0 +1,8 @@
+def test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+    "This function is used by some unit tests only"
+    return "original response"
+
+
+async def async_test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+    "This function is used by some unit tests only"
+    return "original response"

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -280,8 +280,10 @@ class _ExampleRunner:
             warning_class = type(message)
             pattern = failure_warning_messages.get(warning_class, None)
             if pattern and re.compile(pattern).match(str(message)):
+                print("Caught!")
                 caught_failures.append(message)
             else:
+                print("Original")
                 original_showwarning(message, category, filename, lineno, file, line)
 
         warnings.showwarning = showwarning

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -280,13 +280,22 @@ class _ExampleRunner:
             warning_class = type(message)
             pattern = failure_warning_messages.get(warning_class, None)
             if pattern and re.compile(pattern).match(str(message)):
-                print("Caught!")
                 caught_failures.append(message)
             else:
-                print("Original")
                 original_showwarning(message, category, filename, lineno, file, line)
 
         warnings.showwarning = showwarning
+
+        original_logger_warning = asyncio.log.logger.warning
+
+        def logger_warning(msg, *args, **kwargs):
+            if re.compile("^Executing .+ took .+ seconds$").match(str(msg)):
+                caught_failures.append(RuntimeError(msg % args))
+            else:
+                original_logger_warning(msg, *args, **kwargs)
+
+        asyncio.log.logger.warning = logger_warning
+
         aggregated_exceptions = AggregatedExceptions()
 
         try:
@@ -294,6 +303,7 @@ class _ExampleRunner:
                 yield
         finally:
             warnings.showwarning = original_showwarning
+            asyncio.log.logger.warning = original_logger_warning
             for failure in caught_failures:
                 with aggregated_exceptions.catch():
                     raise failure

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -808,8 +808,3 @@ class TestCase(unittest.TestCase):
     @staticmethod
     def mock_constructor(target, class_name):
         return testslide.mock_constructor.mock_constructor(target, class_name)
-
-
-def _test_function(arg1, arg2, kwarg1=None, kwarg2=None):
-    "This function is used by some unit tests only"
-    return "original response"

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -490,6 +490,18 @@ def _patch(target, method, new_value):
         target = testslide._importer(target)
 
     if isinstance(target, StrictMock):
+        template_value = getattr(target.__template, method, None)
+        if (
+            template_value
+            and callable(template_value)
+            and inspect.iscoroutinefunction(template_value)
+        ):
+            raise ValueError(
+                "mock_callable() can not be used with coroutine functions.\n"
+                f"The attribute '{method}' of the template class of {target} "
+                "is a coroutine function. You can use mock_async_callable() "
+                "instead."
+            )
         original_callable = None
     else:
         original_callable = getattr(target, method)
@@ -504,6 +516,12 @@ def _patch(target, method, new_value):
                 "mock_callable() can not be used with with classes: {}. Perhaps you want to use mock_constructor() instead.".format(
                     repr(original_callable)
                 )
+            )
+        if inspect.iscoroutinefunction(original_callable):
+            raise ValueError(
+                "mock_callable() can not be used with coroutine functions.\n"
+                f"{original_callable} is a coroutine function. You can use "
+                "mock_async_callable() instead."
             )
 
     if not isinstance(target, StrictMock):


### PR DESCRIPTION
We'll have `mock_async_callable` to be explicit, so let's make `mock_callable` fail if used with a coroutine function.

Beware this is stacked over `reorganize_mock_callable_tests` branch, beware when merging as it'll contain all of its commits.