### PR TITLE
Implement `mock_async_callable()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,6 +81,7 @@ It is all about letting the failure messages guide you towards the solution. The
    test_runner/index.rst
    strict_mock/index.rst
    mock_callable/index.rst
+   mock_async_callable/index.rst
    mock_constructor/index.rst
    testslide_dsl/index.rst
    code_snippets/index.rst

--- a/docs/mock_async_callable/index.rst
+++ b/docs/mock_async_callable/index.rst
@@ -1,0 +1,37 @@
+mock_async_callable()
+=====================
+
+Just like :doc:`../mock_callable/index` works with regular callables, ``mock_async_callable()`` works with `coroutine functions <https://docs.python.org/3/glossary.html#term-coroutine-function>`_. It implements virtually the same interface (including with all its goodies), with only the following minor differences.
+
+``.with_implementation()``
+--------------------------
+
+It requires an async function:
+
+.. code-block:: python
+
+  async def async_func():
+    return 33
+  
+  self.mock_async_callable(some_object, 'some_method_name')\
+    .with_implementation(async_func)
+  await some_object.some_method_name()  # => 33
+
+``.with_wrapper()``
+-------------------
+
+It requires an async function:
+
+.. code-block:: python
+
+  async def async_trim_query(original_async_callable):
+    return await original_async_callable()[0:5]
+  
+  self.mock_async_callable(some_service, 'big_query')\
+    .with_wrapper(async_trim_query)
+  await some_service.big_query()  # => returns trimmed list
+
+Test Framework Integration
+--------------------------
+
+Follows the exact same model as ``mock_callable()``, but it should be invoked as ``testslide.mock_callable.mock_async_callable``.

--- a/docs/mock_async_callable/index.rst
+++ b/docs/mock_async_callable/index.rst
@@ -31,6 +31,19 @@ It requires an async function:
     .with_wrapper(async_trim_query)
   await some_service.big_query()  # => returns trimmed list
 
+Implicit Coroutine Return
+-------------------------
+
+``mock_async_callable()`` checks if what it is mocking is a coroutine function and refuses to mock if it is not. This is usually a good thing, as it prevents mistakes. If you are trying to mock some callable with it, that is not a coroutine function, but you are **sure** that it returns a coroutine when called, you can still mock it like this:
+
+.. code-block:: python
+
+  self.mock_async_callable(
+    target,
+    "sync_callable_that_returns_a_coroutine",
+    callable_returns_coroutine=True,
+  )
+
 Test Framework Integration
 --------------------------
 

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -6,6 +6,7 @@
 import sys
 import asyncio
 import unittest
+import time
 
 from unittest.mock import Mock, call, patch
 
@@ -1849,6 +1850,16 @@ class SmokeTestAsync(TestDSLBase):
             with self.assertRaisesRegex(
                 RuntimeWarning, "coroutine '.+' was never awaited"
             ):
+                self.run_first_context_first_example()
+
+        def test_fail_if_slow_task(self):
+            @context
+            def top(context):
+                @context.example
+                async def example(self):
+                    time.sleep(0.1)
+
+            with self.assertRaisesRegex(RuntimeError, "^Executing .+ took .+ seconds$"):
                 self.run_first_context_first_example()
 
 

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -80,338 +80,246 @@ class CallOrderTarget(object):
         return "f2: {}".format(repr(arg))
 
 
-@context
-def callable_mocks(context):
-    @context.sub_context("mock_callable()")
-    def mock_callable_tests(context):
+@context("mock_callable()")
+def mock_callable_tests(context):
 
-        ##
-        ## Attributes
-        ##
+    ##
+    ## Attributes
+    ##
 
-        context.memoize("assertions", lambda _: [])
-        context.memoize("call_args", lambda _: ("first", "second"))
-        context.memoize(
-            "call_kwargs", lambda _: {"kwarg1": "first", "kwarg2": "second"}
-        )
+    context.memoize("assertions", lambda _: [])
+    context.memoize("call_args", lambda _: ("first", "second"))
+    context.memoize("call_kwargs", lambda _: {"kwarg1": "first", "kwarg2": "second"})
 
-        @context.memoize
-        def specific_call_args(self):
-            return tuple("specific {}".format(arg) for arg in self.call_args)
+    @context.memoize
+    def specific_call_args(self):
+        return tuple("specific {}".format(arg) for arg in self.call_args)
 
-        @context.memoize
-        def specific_call_kwargs(self):
-            return {k: "specific {}".format(v) for k, v in self.call_kwargs.items()}
+    @context.memoize
+    def specific_call_kwargs(self):
+        return {k: "specific {}".format(v) for k, v in self.call_kwargs.items()}
 
-        ##
-        ## Functions
-        ##
+    ##
+    ## Functions
+    ##
 
-        @context.function
-        def assert_all(self):
-            try:
-                for assertion in self.assertions:
-                    assertion()
-            finally:
-                del self.assertions[:]
-
-        @context.function
-        @contextlib.contextmanager
-        def assertRaisesWithMessage(self, exception, msg):
-            with self.assertRaises(exception) as cm:
-                yield
-            ex_msg = str(cm.exception)
-            self.assertEqual(
-                ex_msg,
-                msg,
-                "Expected exception {}.{} message "
-                "to be\n{}\nbut got\n{}.".format(
-                    exception.__module__, exception.__name__, repr(msg), repr(ex_msg)
-                ),
-            )
-
-        ##
-        ## Hooks
-        ##
-
-        @context.before
-        def register_assertions(self):
-            def register_assertion(assertion):
-                self.assertions.append(assertion)
-
-            testslide.mock_callable.register_assertion = register_assertion
-
-        @context.after
-        def cleanup_patches(self):
-            # Unpatch before assertions, to make sure it is done if assertion fails.
-            testslide.mock_callable.unpatch_all_callable_mocks()
+    @context.function
+    def assert_all(self):
+        try:
             for assertion in self.assertions:
                 assertion()
+        finally:
+            del self.assertions[:]
 
-        ##
-        ## Shared Contexts
-        ##
+    @context.function
+    @contextlib.contextmanager
+    def assertRaisesWithMessage(self, exception, msg):
+        with self.assertRaises(exception) as cm:
+            yield
+        ex_msg = str(cm.exception)
+        self.assertEqual(
+            ex_msg,
+            msg,
+            "Expected exception {}.{} message "
+            "to be\n{}\nbut got\n{}.".format(
+                exception.__module__, exception.__name__, repr(msg), repr(ex_msg)
+            ),
+        )
+
+    ##
+    ## Hooks
+    ##
+
+    @context.before
+    def register_assertions(self):
+        def register_assertion(assertion):
+            self.assertions.append(assertion)
+
+        testslide.mock_callable.register_assertion = register_assertion
+
+    @context.after
+    def cleanup_patches(self):
+        # Unpatch before assertions, to make sure it is done if assertion fails.
+        testslide.mock_callable.unpatch_all_callable_mocks()
+        for assertion in self.assertions:
+            assertion()
+
+    ##
+    ## Shared Contexts
+    ##
+
+    @context.shared_context
+    def mock_configuration_examples(
+        context,
+        callable_accepts_no_args=False,
+        has_original_callable=True,
+        can_yield=True,
+        validate_signature=True,
+    ):
+        @context.function
+        def no_behavior_msg(self):
+            if self.call_args:
+                args_msg = "    {}\n".format(self.call_args)
+            else:
+                args_msg = ""
+            if self.call_kwargs:
+                kwargs_msg = (
+                    "    {\n"
+                    + "".join(
+                        "      {}={},\n".format(k, self.call_kwargs[k])
+                        for k in sorted(self.call_kwargs.keys())
+                    )
+                    + "    }\n"
+                )
+            else:
+                kwargs_msg = ""
+            return str(
+                "{}, {}:\n".format(repr(self.target_arg), repr(self.callable_arg))
+                + "  Received call:\n"
+                + args_msg
+                + kwargs_msg
+                + "  But no behavior was defined for it."
+            )
 
         @context.shared_context
-        def mock_configuration_examples(
-            context,
-            callable_accepts_no_args=False,
-            has_original_callable=True,
-            can_yield=True,
-            validate_signature=True,
-        ):
-            @context.function
-            def no_behavior_msg(self):
-                if self.call_args:
-                    args_msg = "    {}\n".format(self.call_args)
-                else:
-                    args_msg = ""
-                if self.call_kwargs:
-                    kwargs_msg = (
-                        "    {\n"
-                        + "".join(
-                            "      {}={},\n".format(k, self.call_kwargs[k])
-                            for k in sorted(self.call_kwargs.keys())
-                        )
-                        + "    }\n"
-                    )
-                else:
-                    kwargs_msg = ""
-                return str(
-                    "{}, {}:\n".format(repr(self.target_arg), repr(self.callable_arg))
-                    + "  Received call:\n"
-                    + args_msg
-                    + kwargs_msg
-                    + "  But no behavior was defined for it."
-                )
+        def mock_call_arguments(context):
+            @context.example
+            def works_for_matching_signature(self):
+                self.callable_target(*self.call_args, **self.call_kwargs),
 
-            @context.shared_context
-            def mock_call_arguments(context):
+            if validate_signature:
+
                 @context.example
-                def works_for_matching_signature(self):
-                    self.callable_target(*self.call_args, **self.call_kwargs),
+                def raises_TypeError_for_mismatching_signature(self):
+                    args = ("some", "invalid", "args", "list")
+                    kwargs = {"invalid_kwarg": "invalid_value"}
+                    with self.assertRaises(TypeError):
+                        self.callable_target(*args, **kwargs)
 
-                if validate_signature:
+            @context.sub_context(".for_call(*args, **kwargs)")
+            def for_call_args_kwargs(context):
 
-                    @context.example
-                    def raises_TypeError_for_mismatching_signature(self):
-                        args = ("some", "invalid", "args", "list")
-                        kwargs = {"invalid_kwarg": "invalid_value"}
-                        with self.assertRaises(TypeError):
-                            self.callable_target(*args, **kwargs)
+                if not callable_accepts_no_args:
 
-                @context.sub_context(".for_call(*args, **kwargs)")
-                def for_call_args_kwargs(context):
+                    @context.sub_context
+                    def with_matching_signature(context):
+                        @context.before
+                        def before(self):
+                            self.mock_callable_dsl.for_call(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            )
 
-                    if not callable_accepts_no_args:
-
-                        @context.sub_context
-                        def with_matching_signature(context):
-                            @context.before
-                            def before(self):
-                                self.mock_callable_dsl.for_call(
-                                    *self.specific_call_args,
-                                    **self.specific_call_kwargs
-                                )
-
-                            @context.example
-                            def it_accepts_known_arguments(self):
-                                self.callable_target(
-                                    *self.specific_call_args,
-                                    **self.specific_call_kwargs
-                                )
-
-                            if validate_signature:
-
-                                @context.example
-                                def it_rejects_unknown_arguments(self):
-                                    with self.assertRaisesWithMessage(
-                                        UnexpectedCallArguments,
-                                        self.no_behavior_msg()
-                                        + "\n  These are the registered calls:\n"
-                                        + "    {}\n".format(self.specific_call_args)
-                                        + "    {\n"
-                                        + "".join(
-                                            "      {}={},\n".format(
-                                                k, self.specific_call_kwargs[k]
-                                            )
-                                            for k in sorted(
-                                                self.specific_call_kwargs.keys()
-                                            )
-                                        )
-                                        + "    }\n",
-                                    ):
-                                        self.callable_target(
-                                            *self.call_args, **self.call_kwargs
-                                        )
+                        @context.example
+                        def it_accepts_known_arguments(self):
+                            self.callable_target(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            )
 
                         if validate_signature:
 
-                            @context.sub_context
-                            def with_mismatching_signature(context):
-                                @context.xexample
-                                def it_fails_to_mock(self):
-                                    with self.assertRaisesWithMessage(
-                                        ValueError,
-                                        "Can not mock target for arguments that mismatch the "
-                                        "original callable signature.",
-                                    ):
-                                        self.mock_callable_dsl.for_call(
-                                            "some",
-                                            "invalid",
-                                            "args",
-                                            and_some="invalid",
-                                            kwargs="values",
+                            @context.example
+                            def it_rejects_unknown_arguments(self):
+                                with self.assertRaisesWithMessage(
+                                    UnexpectedCallArguments,
+                                    self.no_behavior_msg()
+                                    + "\n  These are the registered calls:\n"
+                                    + "    {}\n".format(self.specific_call_args)
+                                    + "    {\n"
+                                    + "".join(
+                                        "      {}={},\n".format(
+                                            k, self.specific_call_kwargs[k]
                                         )
+                                        for k in sorted(
+                                            self.specific_call_kwargs.keys()
+                                        )
+                                    )
+                                    + "    }\n",
+                                ):
+                                    self.callable_target(
+                                        *self.call_args, **self.call_kwargs
+                                    )
+
+                    if validate_signature:
+
+                        @context.sub_context
+                        def with_mismatching_signature(context):
+                            @context.xexample
+                            def it_fails_to_mock(self):
+                                with self.assertRaisesWithMessage(
+                                    ValueError,
+                                    "Can not mock target for arguments that mismatch the "
+                                    "original callable signature.",
+                                ):
+                                    self.mock_callable_dsl.for_call(
+                                        "some",
+                                        "invalid",
+                                        "args",
+                                        and_some="invalid",
+                                        kwargs="values",
+                                    )
+
+        @context.shared_context
+        def assertions(context):
+            @context.shared_context
+            def assert_failure(context):
+                @context.after
+                def after(self):
+                    with self.assertRaises(AssertionError):
+                        self.assert_all()
 
             @context.shared_context
-            def assertions(context):
-                @context.shared_context
-                def assert_failure(context):
-                    @context.after
-                    def after(self):
-                        with self.assertRaises(AssertionError):
-                            self.assert_all()
+            def not_called(context):
+                @context.example
+                def not_called(self):
+                    pass
 
-                @context.shared_context
-                def not_called(context):
-                    @context.example
-                    def not_called(self):
-                        pass
+            @context.shared_context
+            def called_less_times(context):
+                @context.example
+                def called_less_times(self):
+                    for _ in range(self.times - 1):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
 
-                @context.shared_context
-                def called_less_times(context):
-                    @context.example
-                    def called_less_times(self):
-                        for _ in range(self.times - 1):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
+            @context.shared_context
+            def called_more_times(context):
+                @context.example
+                def called_more_times(self):
+                    for _ in range(self.times + 1):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
 
-                @context.shared_context
-                def called_more_times(context):
-                    @context.example
-                    def called_more_times(self):
-                        for _ in range(self.times + 1):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
+            @context.shared_context
+            def called_more_times_fail(context):
+                @context.example
+                def called_more_times(self):
+                    for _ in range(self.times):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+                    with self.assertRaisesWithMessage(
+                        UnexpectedCallReceived,
+                        (
+                            "Unexpected call received.\n"
+                            "{}, {}:\n"
+                            "  expected to receive at most {} calls with any arguments "
+                            "  but received an extra call."
+                        ).format(
+                            repr(self.target_arg), repr(self.callable_arg), self.times
+                        ),
+                    ):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
 
-                @context.shared_context
-                def called_more_times_fail(context):
-                    @context.example
-                    def called_more_times(self):
-                        for _ in range(self.times):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
-                        with self.assertRaisesWithMessage(
-                            UnexpectedCallReceived,
-                            (
-                                "Unexpected call received.\n"
-                                "{}, {}:\n"
-                                "  expected to receive at most {} calls with any arguments "
-                                "  but received an extra call."
-                            ).format(
-                                repr(self.target_arg),
-                                repr(self.callable_arg),
-                                self.times,
-                            ),
-                        ):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
+            @context.shared_context
+            def called_exactly_times(context):
+                @context.example
+                def called_exactly_times(self):
+                    for _ in range(self.times):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
 
-                @context.shared_context
-                def called_exactly_times(context):
-                    @context.example
-                    def called_exactly_times(self):
-                        for _ in range(self.times):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
-
-                @context.sub_context(".and_assert_called_exactly(times)")
-                def and_assert_called_exactly(context):
-                    @context.sub_context
-                    def with_valid_input(context):
-                        @context.before
-                        def setup_assertion(self):
-                            self.mock_callable_dsl.and_assert_called_exactly(self.times)
-
-                        @context.sub_context
-                        def fails_when(context):
-
-                            context.merge_context("assert failure")
-
-                            context.merge_context("not called")
-                            context.merge_context("called less times")
-                            context.merge_context("called more times fail")
-
-                        @context.sub_context
-                        def passes_when(context):
-
-                            context.merge_context("called exactly times")
-
-                @context.sub_context(".and_assert_called_at_least(times)")
-                def and_assert_called_at_least(context):
-                    @context.sub_context
-                    def with_invalid_input(context):
-                        @context.example("fails to mock when times < 1")
-                        def fails_to_mock_when_times_1(self):
-                            with self.assertRaisesWithMessage(
-                                ValueError, "times must be >= 1"
-                            ):
-                                self.mock_callable_dsl.and_assert_called_at_least(0)
-
-                    @context.sub_context
-                    def with_valid_input(context):
-                        @context.before
-                        def setup_assertion(self):
-                            self.mock_callable_dsl.and_assert_called_at_least(
-                                self.times
-                            )
-
-                        @context.sub_context
-                        def fails_when(context):
-
-                            context.merge_context("assert failure")
-
-                            context.merge_context("not called")
-                            context.merge_context("called less times")
-
-                        @context.sub_context
-                        def passes_when(context):
-
-                            context.merge_context("called exactly times")
-                            context.merge_context("called more times")
-
-                @context.sub_context(".and_assert_called_at_most(times)")
-                def and_assert_called_at_most(context):
-                    @context.sub_context
-                    def with_invalid_input(context):
-                        @context.example("fails to mock when times < 1")
-                        def fails_to_mock_when_times_1(self):
-                            with self.assertRaisesWithMessage(
-                                ValueError, "times must be >= 1"
-                            ):
-                                self.mock_callable_dsl.and_assert_called_at_most(0)
-
-                    @context.sub_context
-                    def with_valid_input(context):
-                        @context.before
-                        def setup_assertion(self):
-                            self.mock_callable_dsl.and_assert_called_at_most(self.times)
-
-                        @context.sub_context
-                        def fails_when(context):
-
-                            context.merge_context("assert failure")
-
-                            context.merge_context("not called")
-                            context.merge_context("called more times fail")
-
-                        @context.sub_context
-                        def passes_when(context):
-
-                            context.merge_context("called less times")
-                            context.merge_context("called exactly times")
-
-                @context.sub_context(".and_assert_called()")
-                def and_assert_called(context):
+            @context.sub_context(".and_assert_called_exactly(times)")
+            def and_assert_called_exactly(context):
+                @context.sub_context
+                def with_valid_input(context):
                     @context.before
                     def setup_assertion(self):
-                        self.mock_callable_dsl.and_assert_called()
+                        self.mock_callable_dsl.and_assert_called_exactly(self.times)
 
                     @context.sub_context
                     def fails_when(context):
@@ -419,430 +327,779 @@ def callable_mocks(context):
                         context.merge_context("assert failure")
 
                         context.merge_context("not called")
+                        context.merge_context("called less times")
+                        context.merge_context("called more times fail")
 
                     @context.sub_context
                     def passes_when(context):
-                        @context.example
-                        def called_once(self):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
 
-                        @context.example
-                        def called_several_times(self):
-                            for _ in range(self.times + 1):
-                                self.callable_target(
-                                    *self.call_args, **self.call_kwargs
-                                )
+                        context.merge_context("called exactly times")
 
-                @context.sub_context(".and_assert_not_called()")
-                def and_assert_not_called(context):
-                    @context.example
-                    def can_use_with_previously_existing_behavior(self):
-                        self.mock_callable_dsl.and_assert_not_called()
+            @context.sub_context(".and_assert_called_at_least(times)")
+            def and_assert_called_at_least(context):
+                @context.sub_context
+                def with_invalid_input(context):
+                    @context.example("fails to mock when times < 1")
+                    def fails_to_mock_when_times_1(self):
+                        with self.assertRaisesWithMessage(
+                            ValueError, "times must be >= 1"
+                        ):
+                            self.mock_callable_dsl.and_assert_called_at_least(0)
 
-            @context.sub_context
-            def default_behavior(context):
-                @context.example
-                def mock_call_fails_with_undefined_behavior(self):
-                    with self.assertRaisesWithMessage(
-                        UndefinedBehaviorForCall, self.no_behavior_msg()
-                    ):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-                @context.sub_context(".and_assert_not_called()")
-                def and_assert_not_called(context):
+                @context.sub_context
+                def with_valid_input(context):
                     @context.before
                     def setup_assertion(self):
-                        self.mock_callable_dsl.and_assert_not_called()
-
-                    @context.sub_context
-                    def passes_when(context):
-                        @context.example
-                        def not_called(self):
-                            pass
+                        self.mock_callable_dsl.and_assert_called_at_least(self.times)
 
                     @context.sub_context
                     def fails_when(context):
-                        @context.after
-                        def after(self):
-                            with self.assertRaises(AssertionError):
-                                self.assert_all()
 
-                        @context.example
-                        def called(self):
-                            with self.assertRaisesWithMessage(
-                                UnexpectedCallReceived,
-                                "{}, {}: Excepted not to be called!".format(
-                                    repr(self.real_target), repr(self.callable_arg)
-                                ),
-                            ):
-                                self.callable_target(
-                                    *self.call_args, **self.call_kwargs
-                                )
+                        context.merge_context("assert failure")
 
-            @context.sub_context(".to_return(value)")
-            def to_return_value(context):
+                        context.merge_context("not called")
+                        context.merge_context("called less times")
 
-                context.memoize("value", lambda _: "mocked value")
-                context.memoize("times", lambda _: 3)
+                    @context.sub_context
+                    def passes_when(context):
 
+                        context.merge_context("called exactly times")
+                        context.merge_context("called more times")
+
+            @context.sub_context(".and_assert_called_at_most(times)")
+            def and_assert_called_at_most(context):
+                @context.sub_context
+                def with_invalid_input(context):
+                    @context.example("fails to mock when times < 1")
+                    def fails_to_mock_when_times_1(self):
+                        with self.assertRaisesWithMessage(
+                            ValueError, "times must be >= 1"
+                        ):
+                            self.mock_callable_dsl.and_assert_called_at_most(0)
+
+                @context.sub_context
+                def with_valid_input(context):
+                    @context.before
+                    def setup_assertion(self):
+                        self.mock_callable_dsl.and_assert_called_at_most(self.times)
+
+                    @context.sub_context
+                    def fails_when(context):
+
+                        context.merge_context("assert failure")
+
+                        context.merge_context("not called")
+                        context.merge_context("called more times fail")
+
+                    @context.sub_context
+                    def passes_when(context):
+
+                        context.merge_context("called less times")
+                        context.merge_context("called exactly times")
+
+            @context.sub_context(".and_assert_called()")
+            def and_assert_called(context):
                 @context.before
-                def setup_mock(self):
-                    self.mock_callable_dsl.to_return_value(self.value)
+                def setup_assertion(self):
+                    self.mock_callable_dsl.and_assert_called()
 
-                if has_original_callable:
-                    context.nest_context("mock call arguments")
-                context.nest_context("assertions")
+                @context.sub_context
+                def fails_when(context):
+
+                    context.merge_context("assert failure")
+
+                    context.merge_context("not called")
+
+                @context.sub_context
+                def passes_when(context):
+                    @context.example
+                    def called_once(self):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+
+                    @context.example
+                    def called_several_times(self):
+                        for _ in range(self.times + 1):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+
+            @context.sub_context(".and_assert_not_called()")
+            def and_assert_not_called(context):
+                @context.example
+                def can_use_with_previously_existing_behavior(self):
+                    self.mock_callable_dsl.and_assert_not_called()
+
+        @context.sub_context
+        def default_behavior(context):
+            @context.example
+            def mock_call_fails_with_undefined_behavior(self):
+                with self.assertRaisesWithMessage(
+                    UndefinedBehaviorForCall, self.no_behavior_msg()
+                ):
+                    self.callable_target(*self.call_args, **self.call_kwargs)
+
+            @context.sub_context(".and_assert_not_called()")
+            def and_assert_not_called(context):
+                @context.before
+                def setup_assertion(self):
+                    self.mock_callable_dsl.and_assert_not_called()
+
+                @context.sub_context
+                def passes_when(context):
+                    @context.example
+                    def not_called(self):
+                        pass
+
+                @context.sub_context
+                def fails_when(context):
+                    @context.after
+                    def after(self):
+                        with self.assertRaises(AssertionError):
+                            self.assert_all()
+
+                    @context.example
+                    def called(self):
+                        with self.assertRaisesWithMessage(
+                            UnexpectedCallReceived,
+                            "{}, {}: Excepted not to be called!".format(
+                                repr(self.real_target), repr(self.callable_arg)
+                            ),
+                        ):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+
+        @context.sub_context(".to_return(value)")
+        def to_return_value(context):
+
+            context.memoize("value", lambda _: "mocked value")
+            context.memoize("times", lambda _: 3)
+
+            @context.before
+            def setup_mock(self):
+                self.mock_callable_dsl.to_return_value(self.value)
+
+            if has_original_callable:
+                context.nest_context("mock call arguments")
+            context.nest_context("assertions")
+
+            @context.example
+            def mock_call_returns_given_value(self):
+                self.assertEqual(
+                    self.callable_target(*self.call_args, **self.call_kwargs),
+                    self.value,
+                )
+                other_args = ["other_arg" for arg in self.call_args]
+                other_kwargs = {k: "other_value" for k in self.call_kwargs}
+                self.assertEqual(
+                    self.callable_target(*other_args, **other_kwargs), self.value
+                )
+
+        @context.sub_context(".to_return_values(values_list)")
+        def to_return_values_values_list(context):
+
+            context.memoize("values_list", lambda _: ["first", "second", "third"])
+            context.memoize("times", lambda self: len(self.values_list) - 1)
+
+            @context.before
+            def setup_mock(self):
+                self.mock_callable_dsl.to_return_values(self.values_list)
+
+            if has_original_callable:
+                context.nest_context("mock call arguments")
+            context.nest_context("assertions")
+
+            @context.example
+            def return_values_from_list_in_order(self):
+                for value in self.values_list:
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs), value
+                    )
+
+            @context.sub_context
+            def when_list_is_exhausted(context):
+                @context.before
+                def before(self):
+                    for _ in self.values_list:
+                        self.callable_target(*self.call_args, **self.call_kwargs)
 
                 @context.example
-                def mock_call_returns_given_value(self):
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs),
-                        self.value,
-                    )
-                    other_args = ["other_arg" for arg in self.call_args]
-                    other_kwargs = {k: "other_value" for k in self.call_kwargs}
-                    self.assertEqual(
-                        self.callable_target(*other_args, **other_kwargs), self.value
-                    )
+                def it_raises(self):
+                    with self.assertRaisesWithMessage(
+                        UndefinedBehaviorForCall, "No more values to return!"
+                    ):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
 
-            @context.sub_context(".to_return_values(values_list)")
-            def to_return_values_values_list(context):
+        if can_yield:
+
+            @context.sub_context(".to_yield_values(values_list)")
+            def to_yield_values_values_list(context):
 
                 context.memoize("values_list", lambda _: ["first", "second", "third"])
                 context.memoize("times", lambda self: len(self.values_list) - 1)
 
                 @context.before
                 def setup_mock(self):
-                    self.mock_callable_dsl.to_return_values(self.values_list)
+                    self.mock_callable_dsl.to_yield_values(self.values_list)
 
                 if has_original_callable:
                     context.nest_context("mock call arguments")
                 context.nest_context("assertions")
 
+                @context.memoize
+                def iterable(self):
+                    return iter(
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+                    )
+
                 @context.example
-                def return_values_from_list_in_order(self):
+                def yield_values_from_list_in_order(self):
                     for value in self.values_list:
-                        self.assertEqual(
-                            self.callable_target(*self.call_args, **self.call_kwargs),
-                            value,
-                        )
+                        self.assertEqual(next(self.iterable), value)
 
                 @context.sub_context
-                def when_list_is_exhausted(context):
+                def when_list_is_empty(context):
                     @context.before
                     def before(self):
                         for _ in self.values_list:
-                            self.callable_target(*self.call_args, **self.call_kwargs)
+                            next(self.iterable)
 
                     @context.example
-                    def it_raises(self):
-                        with self.assertRaisesWithMessage(
-                            UndefinedBehaviorForCall, "No more values to return!"
-                        ):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
+                    def it_raises_StopIteration(self):
+                        with self.assertRaises(StopIteration):
+                            next(self.iterable)
 
-            if can_yield:
+        @context.sub_context(".to_raise(exception)")
+        def to_raise_exception(context):
 
-                @context.sub_context(".to_yield_values(values_list)")
-                def to_yield_values_values_list(context):
+            context.memoize("exception_class", lambda _: RuntimeError)
+            context.memoize("times", lambda _: 3)
 
-                    context.memoize(
-                        "values_list", lambda _: ["first", "second", "third"]
-                    )
-                    context.memoize("times", lambda self: len(self.values_list) - 1)
-
-                    @context.before
-                    def setup_mock(self):
-                        self.mock_callable_dsl.to_yield_values(self.values_list)
-
-                    if has_original_callable:
-                        context.nest_context("mock call arguments")
-                    context.nest_context("assertions")
-
-                    @context.memoize
-                    def iterable(self):
-                        return iter(
-                            self.callable_target(*self.call_args, **self.call_kwargs)
-                        )
-
-                    @context.example
-                    def yield_values_from_list_in_order(self):
-                        for value in self.values_list:
-                            self.assertEqual(next(self.iterable), value)
-
-                    @context.sub_context
-                    def when_list_is_empty(context):
-                        @context.before
-                        def before(self):
-                            for _ in self.values_list:
-                                next(self.iterable)
-
-                        @context.example
-                        def it_raises_StopIteration(self):
-                            with self.assertRaises(StopIteration):
-                                next(self.iterable)
-
-            @context.sub_context(".to_raise(exception)")
-            def to_raise_exception(context):
-
-                context.memoize("exception_class", lambda _: RuntimeError)
-                context.memoize("times", lambda _: 3)
-
-                @context.shared_context
-                def integration(context):
-                    @context.before
-                    def catch_callable_target_exceptions(self):
-                        original_callable_target = self.callable_target
-
-                        def _callable_target(*args, **kwargs):
-                            with self.assertRaises(self.exception_class):
-                                return original_callable_target(*args, **kwargs)
-
-                        self.callable_target = _callable_target
-
-                    if has_original_callable:
-                        context.nest_context("mock call arguments")
-                    context.nest_context("assertions")
-
-                @context.sub_context
-                def when_given_an_exception_class(context):
-                    @context.before
-                    def setup_mock(self):
-                        self.mock_callable_dsl.to_raise(self.exception_class)
-
-                    @context.example
-                    def it_raises_an_instance_of_the_class(self):
-                        with self.assertRaises(self.exception_class):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
-
-                    context.nest_context("integration")
-
-                @context.sub_context
-                def when_given_an_exception_instance(context):
-
-                    context.memoize("exception_message", lambda _: "test exception")
-                    context.memoize(
-                        "exception",
-                        lambda self: self.exception_class(self.exception_message),
-                    )
-
-                    @context.before
-                    def setup_mock(self):
-                        self.mock_callable_dsl.to_raise(self.exception)
-
-                    @context.example
-                    def it_raises_the_exception_instance(self):
-                        with self.assertRaises(self.exception_class) as cm:
-                            self.callable_target(*self.call_args, **self.call_kwargs)
-                        self.assertEqual(self.exception, cm.exception)
-
-                    context.nest_context("integration")
-
-            @context.sub_context(".with_implementation(func)")
-            def with_implementation_func(context):
-
-                context.memoize("times", lambda _: 3)
-                context.memoize("func_return", lambda _: "mocked response")
-
-                @context.memoize
-                def func(self):
-                    def _func(*args, **kwargs):
-                        return self.func_return
-
-                    return _func
-
+            @context.shared_context
+            def integration(context):
                 @context.before
-                def setup_mock(self):
-                    self.mock_callable_dsl.with_implementation(self.func)
+                def catch_callable_target_exceptions(self):
+                    original_callable_target = self.callable_target
+
+                    def _callable_target(*args, **kwargs):
+                        with self.assertRaises(self.exception_class):
+                            return original_callable_target(*args, **kwargs)
+
+                    self.callable_target = _callable_target
 
                 if has_original_callable:
                     context.nest_context("mock call arguments")
                 context.nest_context("assertions")
 
+            @context.sub_context
+            def when_given_an_exception_class(context):
+                @context.before
+                def setup_mock(self):
+                    self.mock_callable_dsl.to_raise(self.exception_class)
+
                 @context.example
-                def it_calls_new_implementation(self):
+                def it_raises_an_instance_of_the_class(self):
+                    with self.assertRaises(self.exception_class):
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+
+                context.nest_context("integration")
+
+            @context.sub_context
+            def when_given_an_exception_instance(context):
+
+                context.memoize("exception_message", lambda _: "test exception")
+                context.memoize(
+                    "exception",
+                    lambda self: self.exception_class(self.exception_message),
+                )
+
+                @context.before
+                def setup_mock(self):
+                    self.mock_callable_dsl.to_raise(self.exception)
+
+                @context.example
+                def it_raises_the_exception_instance(self):
+                    with self.assertRaises(self.exception_class) as cm:
+                        self.callable_target(*self.call_args, **self.call_kwargs)
+                    self.assertEqual(self.exception, cm.exception)
+
+                context.nest_context("integration")
+
+        @context.sub_context(".with_implementation(func)")
+        def with_implementation_func(context):
+
+            context.memoize("times", lambda _: 3)
+            context.memoize("func_return", lambda _: "mocked response")
+
+            @context.memoize
+            def func(self):
+                def _func(*args, **kwargs):
+                    return self.func_return
+
+                return _func
+
+            @context.before
+            def setup_mock(self):
+                self.mock_callable_dsl.with_implementation(self.func)
+
+            if has_original_callable:
+                context.nest_context("mock call arguments")
+            context.nest_context("assertions")
+
+            @context.example
+            def it_calls_new_implementation(self):
+                self.assertEqual(
+                    self.callable_target(*self.call_args, **self.call_kwargs),
+                    self.func_return,
+                )
+
+        @context.sub_context(".with_wrapper(wrapper_func)")
+        def with_wrapper_wrappr_func(context):
+
+            context.memoize("func_return", lambda _: "mocked response")
+
+            @context.memoize
+            def wrapper_func(self):
+                def _wrapper_func(original_function, *args, **kwargs):
+                    self.assertEqual(original_function, self.original_callable)
+                    return self.func_return
+
+                return _wrapper_func
+
+            if has_original_callable:
+
+                context.memoize("times", lambda _: 3)
+
+                @context.before
+                def setup_mock(self):
+                    self.mock_callable_dsl.with_wrapper(self.wrapper_func)
+
+                context.nest_context("mock call arguments")
+                context.nest_context("assertions")
+
+                @context.example
+                def it_calls_wrapper_function(self):
                     self.assertEqual(
                         self.callable_target(*self.call_args, **self.call_kwargs),
                         self.func_return,
                     )
 
-            @context.sub_context(".with_wrapper(wrapper_func)")
-            def with_wrapper_wrappr_func(context):
+            else:
 
-                context.memoize("func_return", lambda _: "mocked response")
-
-                @context.memoize
-                def wrapper_func(self):
-                    def _wrapper_func(original_function, *args, **kwargs):
-                        self.assertEqual(original_function, self.original_callable)
-                        return self.func_return
-
-                    return _wrapper_func
-
-                if has_original_callable:
-
-                    context.memoize("times", lambda _: 3)
-
-                    @context.before
-                    def setup_mock(self):
+                @context.example
+                def it_fails_to_mock(self):
+                    with self.assertRaisesWithMessage(
+                        ValueError,
+                        "Can not wrap original callable that does not exist.",
+                    ):
                         self.mock_callable_dsl.with_wrapper(self.wrapper_func)
 
-                    context.nest_context("mock call arguments")
-                    context.nest_context("assertions")
+        @context.sub_context(".to_call_original()")
+        def to_call_original(context):
 
-                    @context.example
-                    def it_calls_wrapper_function(self):
-                        self.assertEqual(
-                            self.callable_target(*self.call_args, **self.call_kwargs),
-                            self.func_return,
-                        )
+            if has_original_callable:
 
-                else:
+                context.memoize("times", lambda _: 3)
 
-                    @context.example
-                    def it_fails_to_mock(self):
-                        with self.assertRaisesWithMessage(
-                            ValueError,
-                            "Can not wrap original callable that does not exist.",
-                        ):
-                            self.mock_callable_dsl.with_wrapper(self.wrapper_func)
+                @context.before
+                def setup_mock(self):
+                    self.mock_callable_dsl.to_call_original()
 
-            @context.sub_context(".to_call_original()")
-            def to_call_original(context):
+                context.nest_context("mock call arguments")
+                context.nest_context("assertions")
 
-                if has_original_callable:
+                @context.example
+                def it_calls_original_implementation(self):
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs),
+                        self.original_callable(*self.call_args, **self.call_kwargs),
+                    )
 
-                    context.memoize("times", lambda _: 3)
+            else:
 
-                    @context.before
-                    def setup_mock(self):
+                @context.example
+                def it_fails_to_mock(self):
+                    with self.assertRaisesWithMessage(
+                        ValueError,
+                        "Can not call original callable that does not exist.",
+                    ):
                         self.mock_callable_dsl.to_call_original()
 
-                    context.nest_context("mock call arguments")
-                    context.nest_context("assertions")
+        if not callable_accepts_no_args:
 
-                    @context.example
-                    def it_calls_original_implementation(self):
-                        self.assertEqual(
-                            self.callable_target(*self.call_args, **self.call_kwargs),
-                            self.original_callable(*self.call_args, **self.call_kwargs),
-                        )
+            @context.sub_context
+            def composition(context):
+                """
+                This context takes care of composition of multiple
+                call/behavior/assertion combination, to ensure they play along well.
+                """
 
-                else:
+                context.memoize(
+                    "other_args", lambda self: ["other_arg" for arg in self.call_args]
+                )
+                context.memoize(
+                    "other_kwargs",
+                    lambda self: {
+                        k: "other_value" for k, v in self.call_kwargs.items()
+                    },
+                )
 
-                    @context.example
-                    def it_fails_to_mock(self):
-                        with self.assertRaisesWithMessage(
-                            ValueError,
-                            "Can not call original callable that does not exist.",
-                        ):
-                            self.mock_callable_dsl.to_call_original()
-
-            if not callable_accepts_no_args:
+                @context.example
+                def newest_mock_has_precedence_over_older_mocks(self):
+                    """
+                    Mocks are designed to be composable, allowing us to declare
+                    multiple behaviors for different calls. Those definitions stack up,
+                    and when a call is made to the mock, they are searched from newest
+                    to oldest, to find one that is able to be caled.
+                    """
+                    # First, mock all calls
+                    mock_callable(self.target_arg, self.callable_arg).to_return_value(
+                        "any args"
+                    )
+                    # Then we add some specific call behavior
+                    mock_callable(self.target_arg, self.callable_arg).for_call(
+                        *self.specific_call_args, **self.specific_call_kwargs
+                    ).to_return_value("specific")
+                    # The first behavior should still be there
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs),
+                        "any args",
+                    )
+                    # as well as the specific case
+                    self.assertEqual(
+                        self.callable_target(
+                            *self.specific_call_args, **self.specific_call_kwargs
+                        ),
+                        "specific",
+                    )
+                    # but if we add another "catch all" case
+                    mock_callable(self.target_arg, self.callable_arg).to_return_value(
+                        "new any args"
+                    )
+                    # it should take over any previous mock
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs),
+                        "new any args",
+                    )
+                    self.assertEqual(
+                        self.callable_target(
+                            *self.specific_call_args, **self.specific_call_kwargs
+                        ),
+                        "new any args",
+                    )
 
                 @context.sub_context
-                def composition(context):
-                    """
-                    This context takes care of composition of multiple
-                    call/behavior/assertion combination, to ensure they play along well.
-                    """
-
-                    context.memoize(
-                        "other_args",
-                        lambda self: ["other_arg" for arg in self.call_args],
-                    )
-                    context.memoize(
-                        "other_kwargs",
-                        lambda self: {
-                            k: "other_value" for k, v in self.call_kwargs.items()
-                        },
-                    )
-
-                    @context.example
-                    def newest_mock_has_precedence_over_older_mocks(self):
-                        """
-                        Mocks are designed to be composable, allowing us to declare
-                        multiple behaviors for different calls. Those definitions stack up,
-                        and when a call is made to the mock, they are searched from newest
-                        to oldest, to find one that is able to be caled.
-                        """
-                        # First, mock all calls
+                def multiple_assertions(context):
+                    @context.before
+                    def setup_mocks(self):
                         mock_callable(
                             self.target_arg, self.callable_arg
-                        ).to_return_value("any args")
-                        # Then we add some specific call behavior
+                        ).to_return_value("any args").and_assert_called_once()
                         mock_callable(self.target_arg, self.callable_arg).for_call(
                             *self.specific_call_args, **self.specific_call_kwargs
-                        ).to_return_value("specific")
-                        # The first behavior should still be there
-                        self.assertEqual(
-                            self.callable_target(*self.call_args, **self.call_kwargs),
-                            "any args",
+                        ).to_return_value("specific").and_assert_called_twice()
+
+                    @context.example
+                    def that_passes(self):
+                        self.callable_target(*self.other_args, **self.other_kwargs)
+                        self.callable_target(
+                            *self.specific_call_args, **self.specific_call_kwargs
                         )
-                        # as well as the specific case
-                        self.assertEqual(
-                            self.callable_target(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            ),
-                            "specific",
-                        )
-                        # but if we add another "catch all" case
-                        mock_callable(
-                            self.target_arg, self.callable_arg
-                        ).to_return_value("new any args")
-                        # it should take over any previous mock
-                        self.assertEqual(
-                            self.callable_target(*self.call_args, **self.call_kwargs),
-                            "new any args",
-                        )
-                        self.assertEqual(
-                            self.callable_target(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            ),
-                            "new any args",
+                        self.callable_target(
+                            *self.specific_call_args, **self.specific_call_kwargs
                         )
 
-                    @context.sub_context
-                    def multiple_assertions(context):
-                        @context.before
-                        def setup_mocks(self):
-                            mock_callable(
-                                self.target_arg, self.callable_arg
-                            ).to_return_value("any args").and_assert_called_once()
-                            mock_callable(self.target_arg, self.callable_arg).for_call(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            ).to_return_value("specific").and_assert_called_twice()
+                    @context.example
+                    def that_fails(self):
+                        # "Pass" this test when callable accepts no arguments
+                        if (
+                            self.specific_call_args == self.call_args
+                            and self.specific_call_kwargs == self.call_kwargs
+                        ):
+                            raise RuntimeError("FIXME")
+                            return
+                        self.callable_target(*self.other_args, **self.other_kwargs)
+                        self.callable_target(
+                            *self.specific_call_args, **self.specific_call_kwargs
+                        )
+                        with self.assertRaises(AssertionError):
+                            self.assert_all()
 
-                        @context.example
-                        def that_passes(self):
-                            self.callable_target(*self.other_args, **self.other_kwargs)
-                            self.callable_target(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            )
-                            self.callable_target(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            )
+    @context.shared_context
+    def class_is_not_mocked(context):
+        @context.example
+        def class_is_not_mocked(self):
+            mock_callable(self.target_arg, self.callable_arg).to_return_value(
+                "mocked value"
+            )
+            self.assertEqual(
+                self.callable_target(*self.call_args, **self.call_kwargs),
+                "mocked value",
+            )
+            self.assertEqual(
+                getattr(Target, self.callable_arg)(*self.call_args, **self.call_kwargs),
+                "original response",
+            )
 
-                        @context.example
-                        def that_fails(self):
-                            # "Pass" this test when callable accepts no arguments
-                            if (
-                                self.specific_call_args == self.call_args
-                                and self.specific_call_kwargs == self.call_kwargs
-                            ):
-                                raise RuntimeError("FIXME")
-                                return
-                            self.callable_target(*self.other_args, **self.other_kwargs)
-                            self.callable_target(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            )
-                            with self.assertRaises(AssertionError):
-                                self.assert_all()
+    @context.shared_context
+    def can_not_mock_async_callable(context):
+        @context.example
+        def can_not_mock(self):
+            with self.assertRaisesRegex(
+                ValueError,
+                getattr(
+                    self,
+                    "exception_regex_message",
+                    "mock_callable\(\) can not be used with coroutine functions\.",
+                ),
+            ):
+                mock_callable(self.target_arg, self.callable_arg)
+
+    @context.shared_context
+    def async_methods_examples(context, not_in_class_instance_method=False):
+        @context.sub_context
+        def and_callable_is_an_async_instance_method(context):
+            context.memoize("callable_arg", lambda _: "async_instance_method")
+
+            if not_in_class_instance_method:
+
+                @context.memoize
+                def exception_regex_message(self):
+                    return "Patching an instance method at the class is not supported"
+
+            context.merge_context("can not mock async callable")
+
+        @context.sub_context
+        def and_callable_is_an_async_class_method(context):
+            context.memoize("callable_arg", lambda _: "async_class_method")
+
+            context.merge_context("can not mock async callable")
+
+        @context.sub_context
+        def and_callable_is_an_async_static_method(context):
+            context.memoize("callable_arg", lambda _: "async_static_method")
+
+            context.merge_context("can not mock async callable")
+
+        @context.sub_context
+        def and_callable_is_an_async_magic_method(context):
+            context.memoize("callable_arg", lambda _: "__aiter__")
+
+            if not_in_class_instance_method:
+
+                @context.memoize
+                def exception_regex_message(self):
+                    return "Patching an instance method at the class is not supported"
+
+            context.merge_context("can not mock async callable")
+
+    ##
+    ## Contexts
+    ##
+
+    @context.sub_context
+    def call_order_assertion(context):
+        @context.memoize
+        def target1(self):
+            return CallOrderTarget("target1")
+
+        @context.memoize
+        def target2(self):
+            return CallOrderTarget("target2")
+
+        @context.before
+        def define_assertions(self):
+            self.mock_callable(self.target1, "f1").for_call("step 1").to_return_value(
+                "step 1 return"
+            ).and_assert_called_ordered()
+            self.mock_callable(self.target1, "f2").to_return_value(
+                "step 2 return"
+            ).and_assert_called_ordered()
+            self.mock_callable(self.target2, "f1").for_call("step 3").to_return_value(
+                "step 3 return"
+            ).and_assert_called_ordered()
+
+        @context.example
+        def it_passes_with_ordered_calls(self):
+            self.assertEqual(self.target1.f1("step 1"), "step 1 return")
+            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+            self.assert_all()
+
+        @context.example
+        def it_fails_with_unordered_calls(self):
+            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+            self.assertEqual(self.target1.f1("step 1"), "step 1 return")
+            with self.assertRaisesWithMessage(
+                AssertionError,
+                "calls did not match assertion.\n"
+                + "\n"
+                + "These calls were expected to have happened in order:\n"
+                + "\n"
+                + "  target1, {} with arguments:\n".format(repr("f1"))
+                + "    {}\n".format(repr(("step 1",)))
+                + "  target1, {} with any arguments\n".format(repr("f2"))
+                + "  target2, {} with arguments:\n".format(repr("f1"))
+                + "    {}\n".format(repr(("step 3",)))
+                + "\n"
+                + "but these calls were made:\n"
+                + "\n"
+                + "  target1, {} with any arguments\n".format(repr("f2"))
+                + "  target2, {} with arguments:\n".format(repr("f1"))
+                + "    {}\n".format(repr(("step 3",)))
+                + "  target1, {} with arguments:\n".format(repr("f1"))
+                + "    {}".format(repr(("step 1",))),
+            ):
+                self.assert_all()
+
+        @context.example
+        def it_fails_with_partial_calls(self):
+            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+            with self.assertRaisesWithMessage(
+                AssertionError,
+                "calls did not match assertion.\n"
+                + "\n"
+                + "These calls were expected to have happened in order:\n"
+                + "\n"
+                + "  target1, {} with arguments:\n".format(repr("f1"))
+                + "    {}\n".format(repr(("step 1",)))
+                + "  target1, {} with any arguments\n".format(repr("f2"))
+                + "  target2, {} with arguments:\n".format(repr("f1"))
+                + "    {}\n".format(repr(("step 3",)))
+                + "\n"
+                + "but these calls were made:\n"
+                + "\n"
+                + "  target1, {} with any arguments\n".format(repr("f2"))
+                + "  target2, {} with arguments:\n".format(repr("f1"))
+                + "    {}".format(repr(("step 3",))),
+            ):
+                self.assert_all()
+
+        @context.example
+        def other_mocks_do_not_interfere(self):
+            self.mock_callable(self.target1, "f1").for_call(
+                "unrelated 1"
+            ).to_return_value("unrelated 1 return").and_assert_called_once()
+
+            self.assertEqual(self.target1.f1("unrelated 1"), "unrelated 1 return")
+
+            self.mock_callable(self.target2, "f1").for_call(
+                "unrelated 3"
+            ).to_return_value("unrelated 3 return")
+
+            self.assertEqual(self.target1.f1("step 1"), "step 1 return")
+            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+            self.assert_all()
+
+    @context.sub_context
+    def when_target_is_a_module(context):
+        context.memoize("target_arg", lambda _: "tests.sample_module")
+        context.memoize("real_target", lambda _: sample_module)
+
+        @context.example
+        def works_with_alternative_module_names(self):
+            target = "os.path"
+            target_module = os.path
+            alternative_target = "testslide.cli.os.path"
+            import testslide.cli
+
+            alternative_target_module = testslide.cli.os.path
+            original_function = os.path.exists
+
+            self.mock_callable(target, "exists").for_call("found").to_return_value(True)
+            self.mock_callable(alternative_target, "exists").for_call(
+                "not_found"
+            ).to_return_value(False)
+            self.assertTrue(target_module.exists("found"))
+            self.assertTrue(alternative_target_module.exists("found"))
+            self.assertFalse(target_module.exists("not_found"))
+            self.assertFalse(alternative_target_module.exists("not_found"))
+            testslide.mock_callable.unpatch_all_callable_mocks()
+            self.assertEqual(os.path.exists, original_function, "Unpatch did not work")
+
+        @context.sub_context
+        def and_callable_is_a_function(context):
+            @context.before
+            def before(self):
+                self.callable_arg = "test_function"
+                self.original_callable = getattr(self.real_target, self.callable_arg)
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_function(context):
+            context.memoize("callable_arg", lambda _: "async_test_function")
+
+            context.merge_context("can not mock async callable")
+
+    @context.sub_context
+    def when_target_is_a_class(context):
+        @context.before
+        def before(self):
+            self.real_target = Target
+            self.target_arg = Target
+
+        context.merge_context(
+            "async methods examples", not_in_class_instance_method=True
+        )
+
+        @context.sub_context
+        def and_callable_is_an_instance_method(context):
+            @context.example
+            def it_is_not_allowed(self):
+                with self.assertRaises(ValueError):
+                    mock_callable(Target, "instance_method")
+
+        @context.sub_context
+        def and_callable_is_a_class_method(context):
+            @context.before
+            def before(self):
+                self.original_callable = Target.class_method
+                self.callable_arg = "class_method"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = Target.class_method
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_a_static_method(context):
+            @context.before
+            def before(self):
+                self.original_callable = Target.static_method
+                self.callable_arg = "static_method"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = Target.static_method
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_a_magic_method(context):
+            @context.example
+            def it_is_not_allowed(self):
+                with self.assertRaises(ValueError):
+                    mock_callable(Target, "__str__")
+
+    @context.sub_context
+    def an_instance(context):
+        @context.before
+        def before(self):
+            target = Target()
+            self.real_target = target
+            self.target_arg = target
+
+        context.merge_context("async methods examples")
 
         @context.shared_context
-        def class_is_not_mocked(context):
+        def other_instances_are_not_mocked(context):
             @context.example
-            def class_is_not_mocked(self):
+            def other_instances_are_not_mocked(self):
                 mock_callable(self.target_arg, self.callable_arg).to_return_value(
                     "mocked value"
                 )
@@ -851,847 +1108,589 @@ def callable_mocks(context):
                     "mocked value",
                 )
                 self.assertEqual(
-                    getattr(Target, self.callable_arg)(
+                    getattr(Target(), self.callable_arg)(
                         *self.call_args, **self.call_kwargs
                     ),
                     "original response",
                 )
 
-        @context.shared_context
-        def can_not_mock_async_callable(context):
-            @context.example
-            def can_not_mock(self):
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "mock_callable\(\) can not be used with coroutine functions\.",
-                ):
-                    mock_callable(self.target_arg, self.callable_arg)
-
-        @context.shared_context
-        def async_methods_examples(context):
-            @context.sub_context
-            def and_callable_is_an_async_instance_method(context):
-                context.memoize("callable_arg", lambda _: "async_instance_method")
-
-                context.merge_context("can not mock async callable")
-
-            @context.sub_context
-            def and_callable_is_an_async_class_method(context):
-                context.memoize("callable_arg", lambda _: "async_class_method")
-
-                context.merge_context("can not mock async callable")
-
-            @context.sub_context
-            def and_callable_is_an_async_static_method(context):
-                context.memoize("callable_arg", lambda _: "async_static_method")
-
-                context.merge_context("can not mock async callable")
-
-            @context.sub_context
-            def and_callable_is_an_async_magic_method(context):
-                context.memoize("callable_arg", lambda _: "__aiter__")
-
-                context.merge_context("can not mock async callable")
-
-        ##
-        ## Contexts
-        ##
-
         @context.sub_context
-        def call_order_assertion(context):
-            @context.memoize
-            def target1(self):
-                return CallOrderTarget("target1")
+        def and_callable_is_an_instance_method(context):
 
-            @context.memoize
-            def target2(self):
-                return CallOrderTarget("target2")
+            context.memoize("callable_arg", lambda _: "instance_method")
 
-            @context.before
-            def define_assertions(self):
-                self.mock_callable(self.target1, "f1").for_call(
-                    "step 1"
-                ).to_return_value("step 1 return").and_assert_called_ordered()
-                self.mock_callable(self.target1, "f2").to_return_value(
-                    "step 2 return"
-                ).and_assert_called_ordered()
-                self.mock_callable(self.target2, "f1").for_call(
-                    "step 3"
-                ).to_return_value("step 3 return").and_assert_called_ordered()
-
-            @context.example
-            def it_passes_with_ordered_calls(self):
-                self.assertEqual(self.target1.f1("step 1"), "step 1 return")
-                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-                self.assert_all()
-
-            @context.example
-            def it_fails_with_unordered_calls(self):
-                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-                self.assertEqual(self.target1.f1("step 1"), "step 1 return")
-                with self.assertRaisesWithMessage(
-                    AssertionError,
-                    "calls did not match assertion.\n"
-                    + "\n"
-                    + "These calls were expected to have happened in order:\n"
-                    + "\n"
-                    + "  target1, {} with arguments:\n".format(repr("f1"))
-                    + "    {}\n".format(repr(("step 1",)))
-                    + "  target1, {} with any arguments\n".format(repr("f2"))
-                    + "  target2, {} with arguments:\n".format(repr("f1"))
-                    + "    {}\n".format(repr(("step 3",)))
-                    + "\n"
-                    + "but these calls were made:\n"
-                    + "\n"
-                    + "  target1, {} with any arguments\n".format(repr("f2"))
-                    + "  target2, {} with arguments:\n".format(repr("f1"))
-                    + "    {}\n".format(repr(("step 3",)))
-                    + "  target1, {} with arguments:\n".format(repr("f1"))
-                    + "    {}".format(repr(("step 1",))),
-                ):
-                    self.assert_all()
-
-            @context.example
-            def it_fails_with_partial_calls(self):
-                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-                with self.assertRaisesWithMessage(
-                    AssertionError,
-                    "calls did not match assertion.\n"
-                    + "\n"
-                    + "These calls were expected to have happened in order:\n"
-                    + "\n"
-                    + "  target1, {} with arguments:\n".format(repr("f1"))
-                    + "    {}\n".format(repr(("step 1",)))
-                    + "  target1, {} with any arguments\n".format(repr("f2"))
-                    + "  target2, {} with arguments:\n".format(repr("f1"))
-                    + "    {}\n".format(repr(("step 3",)))
-                    + "\n"
-                    + "but these calls were made:\n"
-                    + "\n"
-                    + "  target1, {} with any arguments\n".format(repr("f2"))
-                    + "  target2, {} with arguments:\n".format(repr("f1"))
-                    + "    {}".format(repr(("step 3",))),
-                ):
-                    self.assert_all()
-
-            @context.example
-            def other_mocks_do_not_interfere(self):
-                self.mock_callable(self.target1, "f1").for_call(
-                    "unrelated 1"
-                ).to_return_value("unrelated 1 return").and_assert_called_once()
-
-                self.assertEqual(self.target1.f1("unrelated 1"), "unrelated 1 return")
-
-                self.mock_callable(self.target2, "f1").for_call(
-                    "unrelated 3"
-                ).to_return_value("unrelated 3 return")
-
-                self.assertEqual(self.target1.f1("step 1"), "step 1 return")
-                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-                self.assert_all()
-
-        @context.sub_context
-        def when_target_is_a_module(context):
-            context.memoize("target_arg", lambda _: "tests.sample_module")
-            context.memoize("real_target", lambda _: sample_module)
-
-            @context.example
-            def works_with_alternative_module_names(self):
-                target = "os.path"
-                target_module = os.path
-                alternative_target = "testslide.cli.os.path"
-                import testslide.cli
-
-                alternative_target_module = testslide.cli.os.path
-                original_function = os.path.exists
-
-                self.mock_callable(target, "exists").for_call("found").to_return_value(
-                    True
-                )
-                self.mock_callable(alternative_target, "exists").for_call(
-                    "not_found"
-                ).to_return_value(False)
-                self.assertTrue(target_module.exists("found"))
-                self.assertTrue(alternative_target_module.exists("found"))
-                self.assertFalse(target_module.exists("not_found"))
-                self.assertFalse(alternative_target_module.exists("not_found"))
-                testslide.mock_callable.unpatch_all_callable_mocks()
-                self.assertEqual(
-                    os.path.exists, original_function, "Unpatch did not work"
-                )
-
-            @context.sub_context
-            def and_callable_is_a_function(context):
-                @context.before
-                def before(self):
-                    self.callable_arg = "test_function"
-                    self.original_callable = getattr(
-                        self.real_target, self.callable_arg
-                    )
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_function(context):
-                context.memoize("callable_arg", lambda _: "async_test_function")
-
-                context.merge_context("can not mock async callable")
-
-        @context.sub_context
-        def when_target_is_a_class(context):
             @context.before
             def before(self):
-                self.real_target = Target
-                self.target_arg = Target
+                self.original_callable = self.real_target.instance_method
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = self.real_target.instance_method
 
-            context.merge_context("async methods examples")
-
-            @context.sub_context
-            def and_callable_is_an_instance_method(context):
-                @context.example
-                def it_is_not_allowed(self):
-                    with self.assertRaises(ValueError):
-                        mock_callable(Target, "instance_method")
-
-            @context.sub_context
-            def and_callable_is_a_class_method(context):
-                @context.before
-                def before(self):
-                    self.original_callable = Target.class_method
-                    self.callable_arg = "class_method"
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = Target.class_method
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_a_static_method(context):
-                @context.before
-                def before(self):
-                    self.original_callable = Target.static_method
-                    self.callable_arg = "static_method"
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = Target.static_method
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_a_magic_method(context):
-                @context.example
-                def it_is_not_allowed(self):
-                    with self.assertRaises(ValueError):
-                        mock_callable(Target, "__str__")
+            context.merge_context("mock configuration examples")
+            context.merge_context("other instances are not mocked")
 
         @context.sub_context
-        def an_instance(context):
+        def and_callable_is_a_class_method(context):
             @context.before
             def before(self):
-                target = Target()
-                self.real_target = target
-                self.target_arg = target
+                self.original_callable = self.real_target.class_method
+                self.callable_arg = "class_method"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = self.real_target.class_method
 
-            context.merge_context("async methods examples")
+            context.merge_context("mock configuration examples")
+            context.merge_context("other instances are not mocked")
+            context.merge_context("class is not mocked")
+
+        @context.sub_context
+        def and_callable_is_a_static_method(context):
+            @context.before
+            def before(self):
+                self.original_callable = self.real_target.static_method
+                self.callable_arg = "static_method"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = self.real_target.static_method
+
+            context.merge_context("mock configuration examples")
+            context.merge_context("other instances are not mocked")
+            context.merge_context("class is not mocked")
+
+        @context.sub_context
+        def and_callable_is_a_magic_method(context):
+            context.memoize("call_args", lambda _: ())
+            context.memoize("call_kwargs", lambda _: {})
 
             @context.shared_context
-            def other_instances_are_not_mocked(context):
+            def magic_method_tests(context):
+                @context.before
+                def before(self):
+                    self.original_callable = self.target.__str__
+                    self.real_target = self.target
+                    self.target_arg = self.target
+                    self.callable_arg = "__str__"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = lambda: str(self.target)
+
+                context.merge_context(
+                    "mock configuration examples",
+                    callable_accepts_no_args=True,
+                    can_yield=False,
+                )
+
                 @context.example
                 def other_instances_are_not_mocked(self):
                     mock_callable(self.target_arg, self.callable_arg).to_return_value(
                         "mocked value"
                     )
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs),
-                        "mocked value",
-                    )
-                    self.assertEqual(
-                        getattr(Target(), self.callable_arg)(
-                            *self.call_args, **self.call_kwargs
-                        ),
-                        "original response",
-                    )
+                    self.assertEqual(self.callable_target(), "mocked value")
+                    self.assertEqual(str(Target()), "original response")
 
             @context.sub_context
-            def and_callable_is_an_instance_method(context):
+            def with_magic_method_defined_on_class(context):
+                context.memoize("target", lambda self: ParentTarget())
+                context.merge_context("magic method tests")
 
-                context.memoize("callable_arg", lambda _: "instance_method")
+            @context.sub_context
+            def with_magic_method_defined_on_parent_class(context):
+                context.memoize("target", lambda self: Target())
+                context.merge_context("magic method tests")
 
+    @context.sub_context
+    def when_target_is_a_StrictMock(context):
+        @context.before
+        def before(self):
+            target = StrictMock(template=Target)
+            self.original_callable = None
+            self.real_target = target
+            self.target_arg = target
+
+        context.merge_context("async methods examples")
+
+        @context.shared_context
+        def other_instances_are_not_mocked(context, runtime_attrs=[]):
+            @context.example
+            def other_instances_are_not_mocked(self):
+                mock_callable(self.target_arg, self.callable_arg).to_return_value(
+                    "mocked value"
+                )
+                self.assertEqual(
+                    self.callable_target(*self.call_args, **self.call_kwargs),
+                    "mocked value",
+                )
+                other_strict_mock = StrictMock(
+                    template=Target, runtime_attrs=runtime_attrs
+                )
+                mock_callable(other_strict_mock, self.callable_arg).to_return_value(
+                    "other mocked value"
+                )
+                self.assertEqual(
+                    getattr(other_strict_mock, self.callable_arg)(
+                        *self.call_args, **self.call_kwargs
+                    ),
+                    "other mocked value",
+                )
+
+        @context.sub_context
+        def and_callable_is_an_instance_method(context):
+            context.memoize("callable_arg", lambda _: "instance_method")
+
+            @context.sub_context
+            def that_is_statically_defined_at_the_class(context):
                 @context.before
                 def before(self):
-                    self.original_callable = self.real_target.instance_method
                     self.mock_callable_dsl = mock_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = self.real_target.instance_method
 
-                context.merge_context("mock configuration examples")
+                context.merge_context(
+                    "mock configuration examples", has_original_callable=False
+                )
+
                 context.merge_context("other instances are not mocked")
 
             @context.sub_context
-            def and_callable_is_a_class_method(context):
+            def that_is_dynamically_defined_by_the_instance(context):
+
+                context.memoize("callable_arg", lambda _: "dynamic_instance_method")
+
                 @context.before
                 def before(self):
-                    self.original_callable = self.real_target.class_method
-                    self.callable_arg = "class_method"
+                    target = StrictMock(
+                        template=Target, runtime_attrs=["dynamic_instance_method"]
+                    )
+                    self.original_callable = None
+                    self.real_target = target
+                    self.target_arg = target
                     self.mock_callable_dsl = mock_callable(
                         self.target_arg, self.callable_arg
                     )
-                    self.callable_target = self.real_target.class_method
+                    self.callable_target = target.dynamic_instance_method
 
-                context.merge_context("mock configuration examples")
-                context.merge_context("other instances are not mocked")
-                context.merge_context("class is not mocked")
+                context.merge_context(
+                    "mock configuration examples", has_original_callable=False
+                )
 
-            @context.sub_context
-            def and_callable_is_a_static_method(context):
-                @context.before
-                def before(self):
-                    self.original_callable = self.real_target.static_method
-                    self.callable_arg = "static_method"
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = self.real_target.static_method
-
-                context.merge_context("mock configuration examples")
-                context.merge_context("other instances are not mocked")
-                context.merge_context("class is not mocked")
-
-            @context.sub_context
-            def and_callable_is_a_magic_method(context):
-                context.memoize("call_args", lambda _: ())
-                context.memoize("call_kwargs", lambda _: {})
-
-                @context.shared_context
-                def magic_method_tests(context):
-                    @context.before
-                    def before(self):
-                        self.original_callable = self.target.__str__
-                        self.real_target = self.target
-                        self.target_arg = self.target
-                        self.callable_arg = "__str__"
-                        self.mock_callable_dsl = mock_callable(
-                            self.target_arg, self.callable_arg
-                        )
-                        self.callable_target = lambda: str(self.target)
-
-                    context.merge_context(
-                        "mock configuration examples",
-                        callable_accepts_no_args=True,
-                        can_yield=False,
-                    )
-
-                    @context.example
-                    def other_instances_are_not_mocked(self):
-                        mock_callable(
-                            self.target_arg, self.callable_arg
-                        ).to_return_value("mocked value")
-                        self.assertEqual(self.callable_target(), "mocked value")
-                        self.assertEqual(str(Target()), "original response")
-
-                @context.sub_context
-                def with_magic_method_defined_on_class(context):
-                    context.memoize("target", lambda self: ParentTarget())
-                    context.merge_context("magic method tests")
-
-                @context.sub_context
-                def with_magic_method_defined_on_parent_class(context):
-                    context.memoize("target", lambda self: Target())
-                    context.merge_context("magic method tests")
+                context.merge_context(
+                    "other instances are not mocked",
+                    runtime_attrs=["dynamic_instance_method"],
+                )
 
         @context.sub_context
-        def when_target_is_a_StrictMock(context):
+        def and_callable_is_a_class_method(context):
             @context.before
             def before(self):
-                target = StrictMock(template=Target)
-                self.original_callable = None
-                self.real_target = target
-                self.target_arg = target
-
-            context.merge_context("async methods examples")
-
-            @context.shared_context
-            def other_instances_are_not_mocked(context, runtime_attrs=[]):
-                @context.example
-                def other_instances_are_not_mocked(self):
-                    mock_callable(self.target_arg, self.callable_arg).to_return_value(
-                        "mocked value"
-                    )
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs),
-                        "mocked value",
-                    )
-                    other_strict_mock = StrictMock(
-                        template=Target, runtime_attrs=runtime_attrs
-                    )
-                    mock_callable(other_strict_mock, self.callable_arg).to_return_value(
-                        "other mocked value"
-                    )
-                    self.assertEqual(
-                        getattr(other_strict_mock, self.callable_arg)(
-                            *self.call_args, **self.call_kwargs
-                        ),
-                        "other mocked value",
-                    )
-
-            @context.sub_context
-            def and_callable_is_an_instance_method(context):
-                context.memoize("callable_arg", lambda _: "instance_method")
-
-                @context.sub_context
-                def that_is_statically_defined_at_the_class(context):
-                    @context.before
-                    def before(self):
-                        self.mock_callable_dsl = mock_callable(
-                            self.target_arg, self.callable_arg
-                        )
-                        self.callable_target = self.real_target.instance_method
-
-                    context.merge_context(
-                        "mock configuration examples", has_original_callable=False
-                    )
-
-                    context.merge_context("other instances are not mocked")
-
-                @context.sub_context
-                def that_is_dynamically_defined_by_the_instance(context):
-
-                    context.memoize("callable_arg", lambda _: "dynamic_instance_method")
-
-                    @context.before
-                    def before(self):
-                        target = StrictMock(
-                            template=Target, runtime_attrs=["dynamic_instance_method"]
-                        )
-                        self.original_callable = None
-                        self.real_target = target
-                        self.target_arg = target
-                        self.mock_callable_dsl = mock_callable(
-                            self.target_arg, self.callable_arg
-                        )
-                        self.callable_target = target.dynamic_instance_method
-
-                    context.merge_context(
-                        "mock configuration examples", has_original_callable=False
-                    )
-
-                    context.merge_context(
-                        "other instances are not mocked",
-                        runtime_attrs=["dynamic_instance_method"],
-                    )
-
-            @context.sub_context
-            def and_callable_is_a_class_method(context):
-                @context.before
-                def before(self):
-                    self.callable_arg = "class_method"
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = self.real_target.class_method
-
-                context.merge_context(
-                    "mock configuration examples", has_original_callable=False
+                self.callable_arg = "class_method"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
                 )
-                context.merge_context("other instances are not mocked")
-                context.merge_context("class is not mocked")
+                self.callable_target = self.real_target.class_method
 
-            @context.sub_context
-            def and_callable_is_a_static_method(context):
-                @context.before
-                def before(self):
-                    self.callable_arg = "static_method"
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = self.real_target.static_method
+            context.merge_context(
+                "mock configuration examples", has_original_callable=False
+            )
+            context.merge_context("other instances are not mocked")
+            context.merge_context("class is not mocked")
 
-                context.merge_context(
-                    "mock configuration examples", has_original_callable=False
+        @context.sub_context
+        def and_callable_is_a_static_method(context):
+            @context.before
+            def before(self):
+                self.callable_arg = "static_method"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
                 )
-                context.merge_context("other instances are not mocked")
-                context.merge_context("class is not mocked")
+                self.callable_target = self.real_target.static_method
 
-            @context.sub_context
-            def and_callable_is_a_magic_method(context):
-                context.memoize("call_args", lambda _: ())
-                context.memoize("call_kwargs", lambda _: {})
+            context.merge_context(
+                "mock configuration examples", has_original_callable=False
+            )
+            context.merge_context("other instances are not mocked")
+            context.merge_context("class is not mocked")
 
-                @context.before
-                def before(self):
-                    self.callable_arg = "__str__"
-                    self.mock_callable_dsl = mock_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = lambda: str(self.real_target)
+        @context.sub_context
+        def and_callable_is_a_magic_method(context):
+            context.memoize("call_args", lambda _: ())
+            context.memoize("call_kwargs", lambda _: {})
 
-                context.merge_context(
-                    "mock configuration examples",
-                    callable_accepts_no_args=True,
-                    has_original_callable=False,
-                    can_yield=False,
+            @context.before
+            def before(self):
+                self.callable_arg = "__str__"
+                self.mock_callable_dsl = mock_callable(
+                    self.target_arg, self.callable_arg
                 )
-                context.merge_context("other instances are not mocked")
+                self.callable_target = lambda: str(self.real_target)
 
-    @context.sub_context("mock_async_callable()")
-    def mock_async_callable_tests(context):
+            context.merge_context(
+                "mock configuration examples",
+                callable_accepts_no_args=True,
+                has_original_callable=False,
+                can_yield=False,
+            )
+            context.merge_context("other instances are not mocked")
 
-        ##
-        ## Shared Contexts
-        ##
 
-        @context.shared_context
-        def mock_async_callable_with_sync_exapmles(context):
-            @context.xexample
-            async def can_not_mock(self):
-                with self.assertRaisesRegex(
-                    ValueError,
+@context("mock_async_callable()")
+def mock_async_callable_tests(context):
+
+    ##
+    ## Shared Contexts
+    ##
+
+    @context.shared_context
+    def mock_async_callable_with_sync_exapmles(context):
+        @context.example
+        async def can_not_mock(self):
+            with self.assertRaisesRegex(
+                ValueError,
+                getattr(
+                    self,
+                    "exception_regex_message",
                     "mock_async_callable\(\) can not be used with non coroutine functions\.",
-                ):
-                    mock_async_callable(self.target_arg, self.callable_arg)
+                ),
+            ):
+                mock_async_callable(self.target_arg, self.callable_arg)
+
+        @context.xexample
+        async def can_mock_with_flag(self):
+            pass
+
+    @context.shared_context
+    def mock_configuration_examples(
+        context,
+        callable_accepts_no_args=False,
+        can_yield=False,
+        has_original_callable=True,
+    ):
+        @context.xexample(".for_call()")
+        async def for_call(self):
+            pass
+
+        @context.xexample(".to_return_value(value)")
+        async def to_return_value(self):
+            pass
+
+        @context.xexample(".to_return_values(value_list)")
+        async def to_return_values(self):
+            pass
+
+        @context.xexample(".to_raise(exception)")
+        async def to_raise(self):
+            pass
+
+        @context.xexample(".with_implementation(func)")
+        async def with_implementation(self):
+            pass
+
+        @context.xexample(".with_wrapper(func)")
+        async def with_wrapper(self):
+            pass
+
+        @context.xexample(".to_call_original()")
+        async def to_call_original(self):
+            pass
+
+        @context.xexample(".and_assert_*")
+        async def and_assert(self):
+            pass
+            # .and_assert_called_exactly(times)
+            # .and_assert_called_once()
+            # .and_assert_called_twice()
+            # .and_assert_called_at_least(times)
+            # .and_assert_called_at_most(times)
+            # .and_assert_called()
+            # .and_assert_called_ordered()
+            # .and_assert_not_called()
+
+    @context.shared_context
+    def sync_methods_examples(context, not_in_class_instance_method=False):
+        @context.sub_context
+        def and_callable_is_a_sync_instance_method(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "instance_method"
+
+            if not_in_class_instance_method:
+
+                @context.memoize_before
+                async def exception_regex_message(self):
+                    return "Patching an instance method at the class is not supported"
+
+            context.merge_context("mock async callable with sync exapmles")
+
+        @context.sub_context
+        def and_callable_is_a_sync_class_method(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "class_method"
+
+            context.merge_context("mock async callable with sync exapmles")
+
+        @context.sub_context
+        def and_callable_is_a_sync_static_method(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "static_method"
+
+            context.merge_context("mock async callable with sync exapmles")
+
+        @context.sub_context
+        def and_callable_is_a_sync_magic_method(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "__aiter__"
+
+            if not_in_class_instance_method:
+
+                @context.memoize_before
+                async def exception_regex_message(self):
+                    return "Patching an instance method at the class is not supported"
+
+            context.merge_context("mock async callable with sync exapmles")
+
+    ##
+    ## Contexts
+    ##
+
+    @context.sub_context
+    def when_target_is_a_module(context):
+        @context.memoize_before
+        async def target_arg(self):
+            return "tests.sample_module"
+
+        @context.memoize_before
+        async def real_target(self):
+            return sample_module
+
+        @context.sub_context
+        def and_callable_is_a_function(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "test_function"
+
+            context.merge_context("mock async callable with sync exapmles")
+
+        @context.sub_context
+        def and_callable_is_an_async_function(context):
+            @context.before
+            async def before(self):
+                self.callable_arg = "async_test_function"
+                self.original_callable = getattr(self.real_target, self.callable_arg)
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context("mock configuration examples")
+
+    @context.sub_context
+    def when_target_is_a_class(context):
+        @context.before
+        async def before(self):
+            self.real_target = Target
+            self.target_arg = Target
+
+        context.merge_context(
+            "sync methods examples", not_in_class_instance_method=True
+        )
+
+        @context.sub_context
+        def and_callable_is_an_async_instance_method(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "async_instance_method"
 
             @context.xexample
-            async def can_mock_with_flag(self):
-                pass
-
-        @context.shared_context
-        def mock_configuration_examples(
-            context,
-            callable_accepts_no_args=False,
-            can_yield=False,
-            has_original_callable=True,
-        ):
-            @context.xexample(".for_call()")
-            async def for_call(self):
-                pass
-
-            @context.xexample(".to_return_value(value)")
-            async def to_return_value(self):
-                pass
-
-            @context.xexample(".to_return_values(value_list)")
-            async def to_return_values(self):
-                pass
-
-            @context.xexample(".to_raise(exception)")
-            async def to_raise(self):
-                pass
-
-            @context.xexample(".with_implementation(func)")
-            async def with_implementation(self):
-                pass
-
-            @context.xexample(".with_wrapper(func)")
-            async def with_wrapper(self):
-                pass
-
-            @context.xexample(".to_call_original()")
-            async def to_call_original(self):
-                pass
-
-            @context.xexample(".and_assert_*")
-            async def and_assert(self):
-                pass
-                # .and_assert_called_exactly(times)
-                # .and_assert_called_once()
-                # .and_assert_called_twice()
-                # .and_assert_called_at_least(times)
-                # .and_assert_called_at_most(times)
-                # .and_assert_called()
-                # .and_assert_called_ordered()
-                # .and_assert_not_called()
-
-        @context.shared_context
-        def sync_methods_examples(context):
-            @context.sub_context
-            def and_callable_is_a_sync_instance_method(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "async_instance_method"
-
-                context.merge_context("mock async callable with sync exapmles")
-
-            @context.sub_context
-            def and_callable_is_a_sync_class_method(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "async_class_method"
-
-                context.merge_context("mock async callable with sync exapmles")
-
-            @context.sub_context
-            def and_callable_is_a_sync_static_method(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "async_static_method"
-
-                context.merge_context("mock async callable with sync exapmles")
-
-            @context.sub_context
-            def and_callable_is_a_sync_magic_method(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "__aiter__"
-
-                context.merge_context("mock async callable with sync exapmles")
-
-        ##
-        ## Contexts
-        ##
+            async def it_is_not_allowed(self):
+                with self.assertRaises(ValueError):
+                    mock_async_callable(Target, self.callable_arg)
 
         @context.sub_context
-        def when_target_is_a_module(context):
-            @context.memoize_before
-            async def target_arg(self):
-                return "tests.sample_module"
-
-            @context.memoize_before
-            async def real_target(self):
-                return sample_module
-
-            @context.sub_context
-            def and_callable_is_a_function(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "async_test_function"
-
-                context.merge_context("mock async callable with sync exapmles")
-
-            @context.sub_context
-            def and_callable_is_an_async_function(context):
-                @context.before
-                async def before(self):
-                    self.callable_arg = "async_test_function"
-                    self.original_callable = getattr(
-                        self.real_target, self.callable_arg
-                    )
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context("mock configuration examples")
-
-        @context.sub_context
-        def when_target_is_a_class(context):
+        def and_callable_is_an_async_class_method(context):
             @context.before
             async def before(self):
-                self.real_target = Target
-                self.target_arg = Target
-
-            context.merge_context("sync methods examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_instance_method(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "async_instance_method"
-
-                @context.xexample
-                async def it_is_not_allowed(self):
-                    with self.assertRaises(ValueError):
-                        mock_async_callable(Target, self.callable_arg)
-
-            @context.sub_context
-            def and_callable_is_an_async_class_method(context):
-                @context.before
-                async def before(self):
-                    self.original_callable = Target.class_method
-                    self.callable_arg = "async_class_method"
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = Target.class_method
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_static_method(context):
-                @context.before
-                async def before(self):
-                    self.original_callable = Target.static_method
-                    self.callable_arg = "async_static_method"
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = Target.static_method
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_magic_method(context):
-                @context.xexample
-                async def it_is_not_allowed(self):
-                    with self.assertRaises(ValueError):
-                        mock_async_callable(Target, "__aiter__")
-
-        @context.sub_context
-        def an_instance(context):
-            @context.before
-            async def before(self):
-                target = Target()
-                self.real_target = target
-                self.target_arg = target
-
-            context.merge_context("sync methods examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_instance_method(context):
-                @context.memoize_before
-                async def callable_arg(self):
-                    return "async_instance_method"
-
-                @context.before
-                async def before(self):
-                    self.original_callable = getattr(
-                        self.real_target, self.callable_arg
-                    )
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_class_method(context):
-                @context.before
-                async def before(self):
-                    self.callable_arg = "async_class_method"
-                    self.original_callable = getattr(
-                        self.real_target, self.callable_arg
-                    )
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_static_method(context):
-                @context.before
-                async def before(self):
-                    self.callable_arg = "async_static_method"
-                    self.original_callable = getattr(
-                        self.real_target, self.callable_arg
-                    )
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context("mock configuration examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_magic_method(context):
-                context.memoize_before("call_args", lambda _: ())
-                context.memoize_before("call_kwargs", lambda _: {})
-
-                @context.before
-                async def before(self):
-                    self.callable_arg = "__aiter__"
-                    self.real_target = self.target
-                    self.target_arg = self.real_target
-                    self.original_callable = getattr(
-                        self.real_target, self.callable_arg
-                    )
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    raise NotImplementedError
-                    # self.callable_target = lambda: aiter(self.target)
-
-                context.merge_context(
-                    "mock configuration examples",
-                    callable_accepts_no_args=True,
-                    can_yield=False,
+                self.original_callable = Target.class_method
+                self.callable_arg = "async_class_method"
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
                 )
+                self.callable_target = Target.class_method
+
+            context.merge_context("mock configuration examples")
 
         @context.sub_context
-        def when_target_is_a_StrictMock(context):
+        def and_callable_is_an_async_static_method(context):
+            @context.before
+            async def before(self):
+                self.original_callable = Target.static_method
+                self.callable_arg = "async_static_method"
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = Target.static_method
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_magic_method(context):
+            @context.xexample
+            async def it_is_not_allowed(self):
+                with self.assertRaises(ValueError):
+                    mock_async_callable(Target, "__aiter__")
+
+    @context.xsub_context
+    def an_instance(context):
+        @context.before
+        async def before(self):
+            target = Target()
+            self.real_target = target
+            self.target_arg = target
+
+        context.merge_context("sync methods examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_instance_method(context):
+            @context.memoize_before
+            async def callable_arg(self):
+                return "async_instance_method"
+
+            @context.before
+            async def before(self):
+                self.original_callable = getattr(self.real_target, self.callable_arg)
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_class_method(context):
+            @context.before
+            async def before(self):
+                self.callable_arg = "async_class_method"
+                self.original_callable = getattr(self.real_target, self.callable_arg)
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_static_method(context):
+            @context.before
+            async def before(self):
+                self.callable_arg = "async_static_method"
+                self.original_callable = getattr(self.real_target, self.callable_arg)
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_magic_method(context):
+            context.memoize_before("call_args", lambda _: ())
+            context.memoize_before("call_kwargs", lambda _: {})
+
+            @context.before
+            async def before(self):
+                self.callable_arg = "__aiter__"
+                self.real_target = self.target
+                self.target_arg = self.real_target
+                self.original_callable = getattr(self.real_target, self.callable_arg)
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                raise NotImplementedError
+                # self.callable_target = lambda: aiter(self.target)
+
+            context.merge_context(
+                "mock configuration examples",
+                callable_accepts_no_args=True,
+                can_yield=False,
+            )
+
+    @context.xsub_context
+    def when_target_is_a_StrictMock(context):
+        @context.before
+        def before(self):
+            target = StrictMock(template=Target)
+            self.original_callable = None
+            self.real_target = target
+            self.target_arg = target
+
+        context.merge_context("sync methods examples")
+
+        @context.sub_context
+        def and_callable_is_an_async_instance_method(context):
+            context.memoize_before("callable_arg", lambda _: "async_instance_method")
+
+            @context.before
+            async def before(self):
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context(
+                "mock configuration examples", has_original_callable=False
+            )
+
+        @context.sub_context
+        def and_callable_is_an_async_class_method(context):
+            @context.before
+            async def before(self):
+                self.callable_arg = "async_class_method"
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
+                )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
+
+            context.merge_context(
+                "mock configuration examples", has_original_callable=False
+            )
+
+        @context.sub_context
+        def and_callable_is_a_async_static_method(context):
             @context.before
             def before(self):
-                target = StrictMock(template=Target)
-                self.original_callable = None
-                self.real_target = target
-                self.target_arg = target
-
-            context.merge_context("sync methods examples")
-
-            @context.sub_context
-            def and_callable_is_an_async_instance_method(context):
-                context.memoize_before(
-                    "callable_arg", lambda _: "async_instance_method"
+                self.callable_arg = "async_static_method"
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
                 )
+                self.callable_target = getattr(self.real_target, self.callable_arg)
 
-                @context.before
-                async def before(self):
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
+            context.merge_context(
+                "mock configuration examples", has_original_callable=False
+            )
 
-                context.merge_context(
-                    "mock configuration examples", has_original_callable=False
+        @context.sub_context
+        def and_callable_is_an_async_magic_method(context):
+            context.memoize_before("call_args", lambda _: ())
+            context.memoize_before("call_kwargs", lambda _: {})
+
+            @context.before
+            async def before(self):
+                self.callable_arg = "__aiter__"
+                self.mock_async_callable_dsl = mock_async_callable(
+                    self.target_arg, self.callable_arg
                 )
+                raise NotImplementedError
+                # self.callable_target = lambda: aiter(self.real_target)
 
-            @context.sub_context
-            def and_callable_is_an_async_class_method(context):
-                @context.before
-                async def before(self):
-                    self.callable_arg = "async_class_method"
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context(
-                    "mock configuration examples", has_original_callable=False
-                )
-
-            @context.sub_context
-            def and_callable_is_a_async_static_method(context):
-                @context.before
-                def before(self):
-                    self.callable_arg = "async_static_method"
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    self.callable_target = getattr(self.real_target, self.callable_arg)
-
-                context.merge_context(
-                    "mock configuration examples", has_original_callable=False
-                )
-
-            @context.sub_context
-            def and_callable_is_an_async_magic_method(context):
-                context.memoize_before("call_args", lambda _: ())
-                context.memoize_before("call_kwargs", lambda _: {})
-
-                @context.before
-                async def before(self):
-                    self.callable_arg = "__aiter__"
-                    self.mock_async_callable_dsl = mock_async_callable(
-                        self.target_arg, self.callable_arg
-                    )
-                    raise NotImplementedError
-                    # self.callable_target = lambda: aiter(self.real_target)
-
-                context.merge_context(
-                    "mock configuration examples",
-                    callable_accepts_no_args=True,
-                    has_original_callable=False,
-                    can_yield=False,
-                )
+            context.merge_context(
+                "mock configuration examples",
+                callable_accepts_no_args=True,
+                has_original_callable=False,
+                can_yield=False,
+            )

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -79,1008 +79,769 @@ class CallOrderTarget(object):
         return "f2: {}".format(repr(arg))
 
 
-@context("mock_callable(target, attribute)")
-def mock_callable_context(context):
+@context
+def callable_mocks(context):
+    @context.sub_context("mock_callable()")
+    def mock_callable_tests(context):
 
-    ##
-    ## Attributes
-    ##
+        ##
+        ## Attributes
+        ##
 
-    context.memoize("assertions", lambda _: [])
-    context.memoize("call_args", lambda _: ("first", "second"))
-    context.memoize("call_kwargs", lambda _: {"kwarg1": "first", "kwarg2": "second"})
-
-    @context.memoize
-    def specific_call_args(self):
-        return tuple("specific {}".format(arg) for arg in self.call_args)
-
-    @context.memoize
-    def specific_call_kwargs(self):
-        return {k: "specific {}".format(v) for k, v in self.call_kwargs.items()}
-
-    ##
-    ## Functions
-    ##
-
-    @context.function
-    def assert_all(self):
-        try:
-            for assertion in self.assertions:
-                assertion()
-        finally:
-            del self.assertions[:]
-
-    @context.function
-    @contextlib.contextmanager
-    def assertRaisesWithMessage(self, exception, msg):
-        with self.assertRaises(exception) as cm:
-            yield
-        ex_msg = str(cm.exception)
-        self.assertEqual(
-            ex_msg,
-            msg,
-            "Expected exception {}.{} message "
-            "to be\n{}\nbut got\n{}.".format(
-                exception.__module__, exception.__name__, repr(msg), repr(ex_msg)
-            ),
+        context.memoize("assertions", lambda _: [])
+        context.memoize("call_args", lambda _: ("first", "second"))
+        context.memoize(
+            "call_kwargs", lambda _: {"kwarg1": "first", "kwarg2": "second"}
         )
 
-    ##
-    ## Hooks
-    ##
+        @context.memoize
+        def specific_call_args(self):
+            return tuple("specific {}".format(arg) for arg in self.call_args)
 
-    @context.before
-    def register_assertions(self):
-        def register_assertion(assertion):
-            self.assertions.append(assertion)
+        @context.memoize
+        def specific_call_kwargs(self):
+            return {k: "specific {}".format(v) for k, v in self.call_kwargs.items()}
 
-        testslide.mock_callable.register_assertion = register_assertion
+        ##
+        ## Functions
+        ##
 
-    @context.after
-    def cleanup_patches(self):
-        # Unpatch before assertions, to make sure it is done if assertion fails.
-        testslide.mock_callable.unpatch_all_callable_mocks()
-        for assertion in self.assertions:
-            assertion()
-
-    ##
-    ## Shared Contexts
-    ##
-
-    @context.shared_context
-    def examples_for_target(
-        context,
-        callable_accepts_no_args=False,
-        has_original_callable=True,
-        can_yield=True,
-        validate_signature=True,
-    ):
         @context.function
-        def no_behavior_msg(self):
-            if self.call_args:
-                args_msg = "    {}\n".format(self.call_args)
-            else:
-                args_msg = ""
-            if self.call_kwargs:
-                kwargs_msg = (
-                    "    {\n"
-                    + "".join(
-                        "      {}={},\n".format(k, self.call_kwargs[k])
-                        for k in sorted(self.call_kwargs.keys())
-                    )
-                    + "    }\n"
-                )
-            else:
-                kwargs_msg = ""
-            return str(
-                "{}, {}:\n".format(repr(self.target_arg), repr(self.callable_arg))
-                + "  Received call:\n"
-                + args_msg
-                + kwargs_msg
-                + "  But no behavior was defined for it."
+        def assert_all(self):
+            try:
+                for assertion in self.assertions:
+                    assertion()
+            finally:
+                del self.assertions[:]
+
+        @context.function
+        @contextlib.contextmanager
+        def assertRaisesWithMessage(self, exception, msg):
+            with self.assertRaises(exception) as cm:
+                yield
+            ex_msg = str(cm.exception)
+            self.assertEqual(
+                ex_msg,
+                msg,
+                "Expected exception {}.{} message "
+                "to be\n{}\nbut got\n{}.".format(
+                    exception.__module__, exception.__name__, repr(msg), repr(ex_msg)
+                ),
             )
 
+        ##
+        ## Hooks
+        ##
+
+        @context.before
+        def register_assertions(self):
+            def register_assertion(assertion):
+                self.assertions.append(assertion)
+
+            testslide.mock_callable.register_assertion = register_assertion
+
+        @context.after
+        def cleanup_patches(self):
+            # Unpatch before assertions, to make sure it is done if assertion fails.
+            testslide.mock_callable.unpatch_all_callable_mocks()
+            for assertion in self.assertions:
+                assertion()
+
+        ##
+        ## Shared Contexts
+        ##
+
         @context.shared_context
-        def mock_call_arguments(context):
-            @context.example
-            def works_for_matching_signature(self):
-                self.callable_target(*self.call_args, **self.call_kwargs),
+        def mock_configuration_examples(
+            context,
+            callable_accepts_no_args=False,
+            has_original_callable=True,
+            can_yield=True,
+            validate_signature=True,
+        ):
+            @context.function
+            def no_behavior_msg(self):
+                if self.call_args:
+                    args_msg = "    {}\n".format(self.call_args)
+                else:
+                    args_msg = ""
+                if self.call_kwargs:
+                    kwargs_msg = (
+                        "    {\n"
+                        + "".join(
+                            "      {}={},\n".format(k, self.call_kwargs[k])
+                            for k in sorted(self.call_kwargs.keys())
+                        )
+                        + "    }\n"
+                    )
+                else:
+                    kwargs_msg = ""
+                return str(
+                    "{}, {}:\n".format(repr(self.target_arg), repr(self.callable_arg))
+                    + "  Received call:\n"
+                    + args_msg
+                    + kwargs_msg
+                    + "  But no behavior was defined for it."
+                )
 
-            if validate_signature:
-
+            @context.shared_context
+            def mock_call_arguments(context):
                 @context.example
-                def raises_TypeError_for_mismatching_signature(self):
-                    args = ("some", "invalid", "args", "list")
-                    kwargs = {"invalid_kwarg": "invalid_value"}
-                    with self.assertRaises(TypeError):
-                        self.callable_target(*args, **kwargs)
+                def works_for_matching_signature(self):
+                    self.callable_target(*self.call_args, **self.call_kwargs),
 
-            @context.sub_context(".for_call(*args, **kwargs)")
-            def for_call_args_kwargs(context):
+                if validate_signature:
 
-                if not callable_accepts_no_args:
+                    @context.example
+                    def raises_TypeError_for_mismatching_signature(self):
+                        args = ("some", "invalid", "args", "list")
+                        kwargs = {"invalid_kwarg": "invalid_value"}
+                        with self.assertRaises(TypeError):
+                            self.callable_target(*args, **kwargs)
 
-                    @context.sub_context
-                    def with_matching_signature(context):
-                        @context.before
-                        def before(self):
-                            self.mock_callable_dsl.for_call(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            )
+                @context.sub_context(".for_call(*args, **kwargs)")
+                def for_call_args_kwargs(context):
 
-                        @context.example
-                        def it_accepts_known_arguments(self):
-                            self.callable_target(
-                                *self.specific_call_args, **self.specific_call_kwargs
-                            )
+                    if not callable_accepts_no_args:
+
+                        @context.sub_context
+                        def with_matching_signature(context):
+                            @context.before
+                            def before(self):
+                                self.mock_callable_dsl.for_call(
+                                    *self.specific_call_args,
+                                    **self.specific_call_kwargs
+                                )
+
+                            @context.example
+                            def it_accepts_known_arguments(self):
+                                self.callable_target(
+                                    *self.specific_call_args,
+                                    **self.specific_call_kwargs
+                                )
+
+                            if validate_signature:
+
+                                @context.example
+                                def it_rejects_unknown_arguments(self):
+                                    with self.assertRaisesWithMessage(
+                                        UnexpectedCallArguments,
+                                        self.no_behavior_msg()
+                                        + "\n  These are the registered calls:\n"
+                                        + "    {}\n".format(self.specific_call_args)
+                                        + "    {\n"
+                                        + "".join(
+                                            "      {}={},\n".format(
+                                                k, self.specific_call_kwargs[k]
+                                            )
+                                            for k in sorted(
+                                                self.specific_call_kwargs.keys()
+                                            )
+                                        )
+                                        + "    }\n",
+                                    ):
+                                        self.callable_target(
+                                            *self.call_args, **self.call_kwargs
+                                        )
 
                         if validate_signature:
 
-                            @context.example
-                            def it_rejects_unknown_arguments(self):
-                                with self.assertRaisesWithMessage(
-                                    UnexpectedCallArguments,
-                                    self.no_behavior_msg()
-                                    + "\n  These are the registered calls:\n"
-                                    + "    {}\n".format(self.specific_call_args)
-                                    + "    {\n"
-                                    + "".join(
-                                        "      {}={},\n".format(
-                                            k, self.specific_call_kwargs[k]
+                            @context.sub_context
+                            def with_mismatching_signature(context):
+                                @context.xexample
+                                def it_fails_to_mock(self):
+                                    with self.assertRaisesWithMessage(
+                                        ValueError,
+                                        "Can not mock target for arguments that mismatch the "
+                                        "original callable signature.",
+                                    ):
+                                        self.mock_callable_dsl.for_call(
+                                            "some",
+                                            "invalid",
+                                            "args",
+                                            and_some="invalid",
+                                            kwargs="values",
                                         )
-                                        for k in sorted(
-                                            self.specific_call_kwargs.keys()
-                                        )
-                                    )
-                                    + "    }\n",
-                                ):
-                                    self.callable_target(
-                                        *self.call_args, **self.call_kwargs
-                                    )
-
-                    if validate_signature:
-
-                        @context.sub_context
-                        def with_mismatching_signature(context):
-                            @context.xexample
-                            def it_fails_to_mock(self):
-                                with self.assertRaisesWithMessage(
-                                    ValueError,
-                                    "Can not mock target for arguments that mismatch the "
-                                    "original callable signature.",
-                                ):
-                                    self.mock_callable_dsl.for_call(
-                                        "some",
-                                        "invalid",
-                                        "args",
-                                        and_some="invalid",
-                                        kwargs="values",
-                                    )
-
-        @context.shared_context
-        def assertions(context):
-            @context.shared_context
-            def assert_failure(context):
-                @context.after
-                def after(self):
-                    with self.assertRaises(AssertionError):
-                        self.assert_all()
 
             @context.shared_context
-            def not_called(context):
-                @context.example
-                def not_called(self):
-                    pass
-
-            @context.shared_context
-            def called_less_times(context):
-                @context.example
-                def called_less_times(self):
-                    for _ in range(self.times - 1):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-            @context.shared_context
-            def called_more_times(context):
-                @context.example
-                def called_more_times(self):
-                    for _ in range(self.times + 1):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-            @context.shared_context
-            def called_more_times_fail(context):
-                @context.example
-                def called_more_times(self):
-                    for _ in range(self.times):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-                    with self.assertRaisesWithMessage(
-                        UnexpectedCallReceived,
-                        (
-                            "Unexpected call received.\n"
-                            "{}, {}:\n"
-                            "  expected to receive at most {} calls with any arguments "
-                            "  but received an extra call."
-                        ).format(
-                            repr(self.target_arg), repr(self.callable_arg), self.times
-                        ),
-                    ):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-            @context.shared_context
-            def called_exactly_times(context):
-                @context.example
-                def called_exactly_times(self):
-                    for _ in range(self.times):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-            @context.sub_context(".and_assert_called_exactly(times)")
-            def and_assert_called_exactly(context):
-                @context.sub_context
-                def with_valid_input(context):
-                    @context.before
-                    def setup_assertion(self):
-                        self.mock_callable_dsl.and_assert_called_exactly(self.times)
-
-                    @context.sub_context
-                    def fails_when(context):
-
-                        context.merge_context("assert failure")
-
-                        context.merge_context("not called")
-                        context.merge_context("called less times")
-                        context.merge_context("called more times fail")
-
-                    @context.sub_context
-                    def passes_when(context):
-
-                        context.merge_context("called exactly times")
-
-            @context.sub_context(".and_assert_called_at_least(times)")
-            def and_assert_called_at_least(context):
-                @context.sub_context
-                def with_invalid_input(context):
-                    @context.example("fails to mock when times < 1")
-                    def fails_to_mock_when_times_1(self):
-                        with self.assertRaisesWithMessage(
-                            ValueError, "times must be >= 1"
-                        ):
-                            self.mock_callable_dsl.and_assert_called_at_least(0)
-
-                @context.sub_context
-                def with_valid_input(context):
-                    @context.before
-                    def setup_assertion(self):
-                        self.mock_callable_dsl.and_assert_called_at_least(self.times)
-
-                    @context.sub_context
-                    def fails_when(context):
-
-                        context.merge_context("assert failure")
-
-                        context.merge_context("not called")
-                        context.merge_context("called less times")
-
-                    @context.sub_context
-                    def passes_when(context):
-
-                        context.merge_context("called exactly times")
-                        context.merge_context("called more times")
-
-            @context.sub_context(".and_assert_called_at_most(times)")
-            def and_assert_called_at_most(context):
-                @context.sub_context
-                def with_invalid_input(context):
-                    @context.example("fails to mock when times < 1")
-                    def fails_to_mock_when_times_1(self):
-                        with self.assertRaisesWithMessage(
-                            ValueError, "times must be >= 1"
-                        ):
-                            self.mock_callable_dsl.and_assert_called_at_most(0)
-
-                @context.sub_context
-                def with_valid_input(context):
-                    @context.before
-                    def setup_assertion(self):
-                        self.mock_callable_dsl.and_assert_called_at_most(self.times)
-
-                    @context.sub_context
-                    def fails_when(context):
-
-                        context.merge_context("assert failure")
-
-                        context.merge_context("not called")
-                        context.merge_context("called more times fail")
-
-                    @context.sub_context
-                    def passes_when(context):
-
-                        context.merge_context("called less times")
-                        context.merge_context("called exactly times")
-
-            @context.sub_context(".and_assert_called()")
-            def and_assert_called(context):
-                @context.before
-                def setup_assertion(self):
-                    self.mock_callable_dsl.and_assert_called()
-
-                @context.sub_context
-                def fails_when(context):
-
-                    context.merge_context("assert failure")
-
-                    context.merge_context("not called")
-
-                @context.sub_context
-                def passes_when(context):
-                    @context.example
-                    def called_once(self):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-                    @context.example
-                    def called_several_times(self):
-                        for _ in range(self.times + 1):
-                            self.callable_target(*self.call_args, **self.call_kwargs)
-
-            @context.sub_context(".and_assert_not_called()")
-            def and_assert_not_called(context):
-                @context.example
-                def can_use_with_previously_existing_behavior(self):
-                    self.mock_callable_dsl.and_assert_not_called()
-
-        @context.sub_context
-        def default_behavior(context):
-            @context.example
-            def mock_call_fails_with_undefined_behavior(self):
-                with self.assertRaisesWithMessage(
-                    UndefinedBehaviorForCall, self.no_behavior_msg()
-                ):
-                    self.callable_target(*self.call_args, **self.call_kwargs)
-
-            @context.sub_context(".and_assert_not_called()")
-            def and_assert_not_called(context):
-                @context.before
-                def setup_assertion(self):
-                    self.mock_callable_dsl.and_assert_not_called()
-
-                @context.sub_context
-                def passes_when(context):
-                    @context.example
-                    def not_called(self):
-                        pass
-
-                @context.sub_context
-                def fails_when(context):
+            def assertions(context):
+                @context.shared_context
+                def assert_failure(context):
                     @context.after
                     def after(self):
                         with self.assertRaises(AssertionError):
                             self.assert_all()
 
+                @context.shared_context
+                def not_called(context):
                     @context.example
-                    def called(self):
+                    def not_called(self):
+                        pass
+
+                @context.shared_context
+                def called_less_times(context):
+                    @context.example
+                    def called_less_times(self):
+                        for _ in range(self.times - 1):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+
+                @context.shared_context
+                def called_more_times(context):
+                    @context.example
+                    def called_more_times(self):
+                        for _ in range(self.times + 1):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+
+                @context.shared_context
+                def called_more_times_fail(context):
+                    @context.example
+                    def called_more_times(self):
+                        for _ in range(self.times):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
                         with self.assertRaisesWithMessage(
                             UnexpectedCallReceived,
-                            "{}, {}: Excepted not to be called!".format(
-                                repr(self.real_target), repr(self.callable_arg)
+                            (
+                                "Unexpected call received.\n"
+                                "{}, {}:\n"
+                                "  expected to receive at most {} calls with any arguments "
+                                "  but received an extra call."
+                            ).format(
+                                repr(self.target_arg),
+                                repr(self.callable_arg),
+                                self.times,
                             ),
                         ):
                             self.callable_target(*self.call_args, **self.call_kwargs)
 
-        @context.sub_context(".to_return(value)")
-        def to_return_value(context):
+                @context.shared_context
+                def called_exactly_times(context):
+                    @context.example
+                    def called_exactly_times(self):
+                        for _ in range(self.times):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
 
-            context.memoize("value", lambda _: "mocked value")
-            context.memoize("times", lambda _: 3)
+                @context.sub_context(".and_assert_called_exactly(times)")
+                def and_assert_called_exactly(context):
+                    @context.sub_context
+                    def with_valid_input(context):
+                        @context.before
+                        def setup_assertion(self):
+                            self.mock_callable_dsl.and_assert_called_exactly(self.times)
 
-            @context.before
-            def setup_mock(self):
-                self.mock_callable_dsl.to_return_value(self.value)
+                        @context.sub_context
+                        def fails_when(context):
 
-            if has_original_callable:
-                context.nest_context("mock call arguments")
-            context.nest_context("assertions")
+                            context.merge_context("assert failure")
 
-            @context.example
-            def mock_call_returns_given_value(self):
-                self.assertEqual(
-                    self.callable_target(*self.call_args, **self.call_kwargs),
-                    self.value,
-                )
-                other_args = ["other_arg" for arg in self.call_args]
-                other_kwargs = {k: "other_value" for k in self.call_kwargs}
-                self.assertEqual(
-                    self.callable_target(*other_args, **other_kwargs), self.value
-                )
+                            context.merge_context("not called")
+                            context.merge_context("called less times")
+                            context.merge_context("called more times fail")
 
-        @context.sub_context(".to_return_values(values_list)")
-        def to_return_values_values_list(context):
+                        @context.sub_context
+                        def passes_when(context):
 
-            context.memoize("values_list", lambda _: ["first", "second", "third"])
-            context.memoize("times", lambda self: len(self.values_list) - 1)
+                            context.merge_context("called exactly times")
 
-            @context.before
-            def setup_mock(self):
-                self.mock_callable_dsl.to_return_values(self.values_list)
+                @context.sub_context(".and_assert_called_at_least(times)")
+                def and_assert_called_at_least(context):
+                    @context.sub_context
+                    def with_invalid_input(context):
+                        @context.example("fails to mock when times < 1")
+                        def fails_to_mock_when_times_1(self):
+                            with self.assertRaisesWithMessage(
+                                ValueError, "times must be >= 1"
+                            ):
+                                self.mock_callable_dsl.and_assert_called_at_least(0)
 
-            if has_original_callable:
-                context.nest_context("mock call arguments")
-            context.nest_context("assertions")
+                    @context.sub_context
+                    def with_valid_input(context):
+                        @context.before
+                        def setup_assertion(self):
+                            self.mock_callable_dsl.and_assert_called_at_least(
+                                self.times
+                            )
 
-            @context.example
-            def return_values_from_list_in_order(self):
-                for value in self.values_list:
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs), value
-                    )
+                        @context.sub_context
+                        def fails_when(context):
+
+                            context.merge_context("assert failure")
+
+                            context.merge_context("not called")
+                            context.merge_context("called less times")
+
+                        @context.sub_context
+                        def passes_when(context):
+
+                            context.merge_context("called exactly times")
+                            context.merge_context("called more times")
+
+                @context.sub_context(".and_assert_called_at_most(times)")
+                def and_assert_called_at_most(context):
+                    @context.sub_context
+                    def with_invalid_input(context):
+                        @context.example("fails to mock when times < 1")
+                        def fails_to_mock_when_times_1(self):
+                            with self.assertRaisesWithMessage(
+                                ValueError, "times must be >= 1"
+                            ):
+                                self.mock_callable_dsl.and_assert_called_at_most(0)
+
+                    @context.sub_context
+                    def with_valid_input(context):
+                        @context.before
+                        def setup_assertion(self):
+                            self.mock_callable_dsl.and_assert_called_at_most(self.times)
+
+                        @context.sub_context
+                        def fails_when(context):
+
+                            context.merge_context("assert failure")
+
+                            context.merge_context("not called")
+                            context.merge_context("called more times fail")
+
+                        @context.sub_context
+                        def passes_when(context):
+
+                            context.merge_context("called less times")
+                            context.merge_context("called exactly times")
+
+                @context.sub_context(".and_assert_called()")
+                def and_assert_called(context):
+                    @context.before
+                    def setup_assertion(self):
+                        self.mock_callable_dsl.and_assert_called()
+
+                    @context.sub_context
+                    def fails_when(context):
+
+                        context.merge_context("assert failure")
+
+                        context.merge_context("not called")
+
+                    @context.sub_context
+                    def passes_when(context):
+                        @context.example
+                        def called_once(self):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+
+                        @context.example
+                        def called_several_times(self):
+                            for _ in range(self.times + 1):
+                                self.callable_target(
+                                    *self.call_args, **self.call_kwargs
+                                )
+
+                @context.sub_context(".and_assert_not_called()")
+                def and_assert_not_called(context):
+                    @context.example
+                    def can_use_with_previously_existing_behavior(self):
+                        self.mock_callable_dsl.and_assert_not_called()
 
             @context.sub_context
-            def when_list_is_exhausted(context):
-                @context.before
-                def before(self):
-                    for _ in self.values_list:
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
+            def default_behavior(context):
                 @context.example
-                def it_raises(self):
+                def mock_call_fails_with_undefined_behavior(self):
                     with self.assertRaisesWithMessage(
-                        UndefinedBehaviorForCall, "No more values to return!"
+                        UndefinedBehaviorForCall, self.no_behavior_msg()
                     ):
                         self.callable_target(*self.call_args, **self.call_kwargs)
 
-        if can_yield:
+                @context.sub_context(".and_assert_not_called()")
+                def and_assert_not_called(context):
+                    @context.before
+                    def setup_assertion(self):
+                        self.mock_callable_dsl.and_assert_not_called()
 
-            @context.sub_context(".to_yield_values(values_list)")
-            def to_yield_values_values_list(context):
+                    @context.sub_context
+                    def passes_when(context):
+                        @context.example
+                        def not_called(self):
+                            pass
+
+                    @context.sub_context
+                    def fails_when(context):
+                        @context.after
+                        def after(self):
+                            with self.assertRaises(AssertionError):
+                                self.assert_all()
+
+                        @context.example
+                        def called(self):
+                            with self.assertRaisesWithMessage(
+                                UnexpectedCallReceived,
+                                "{}, {}: Excepted not to be called!".format(
+                                    repr(self.real_target), repr(self.callable_arg)
+                                ),
+                            ):
+                                self.callable_target(
+                                    *self.call_args, **self.call_kwargs
+                                )
+
+            @context.sub_context(".to_return(value)")
+            def to_return_value(context):
+
+                context.memoize("value", lambda _: "mocked value")
+                context.memoize("times", lambda _: 3)
+
+                @context.before
+                def setup_mock(self):
+                    self.mock_callable_dsl.to_return_value(self.value)
+
+                if has_original_callable:
+                    context.nest_context("mock call arguments")
+                context.nest_context("assertions")
+
+                @context.example
+                def mock_call_returns_given_value(self):
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs),
+                        self.value,
+                    )
+                    other_args = ["other_arg" for arg in self.call_args]
+                    other_kwargs = {k: "other_value" for k in self.call_kwargs}
+                    self.assertEqual(
+                        self.callable_target(*other_args, **other_kwargs), self.value
+                    )
+
+            @context.sub_context(".to_return_values(values_list)")
+            def to_return_values_values_list(context):
 
                 context.memoize("values_list", lambda _: ["first", "second", "third"])
                 context.memoize("times", lambda self: len(self.values_list) - 1)
 
                 @context.before
                 def setup_mock(self):
-                    self.mock_callable_dsl.to_yield_values(self.values_list)
+                    self.mock_callable_dsl.to_return_values(self.values_list)
 
                 if has_original_callable:
                     context.nest_context("mock call arguments")
                 context.nest_context("assertions")
 
-                @context.memoize
-                def iterable(self):
-                    return iter(
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-                    )
-
                 @context.example
-                def yield_values_from_list_in_order(self):
+                def return_values_from_list_in_order(self):
                     for value in self.values_list:
-                        self.assertEqual(next(self.iterable), value)
+                        self.assertEqual(
+                            self.callable_target(*self.call_args, **self.call_kwargs),
+                            value,
+                        )
 
                 @context.sub_context
-                def when_list_is_empty(context):
+                def when_list_is_exhausted(context):
                     @context.before
                     def before(self):
                         for _ in self.values_list:
-                            next(self.iterable)
+                            self.callable_target(*self.call_args, **self.call_kwargs)
 
                     @context.example
-                    def it_raises_StopIteration(self):
-                        with self.assertRaises(StopIteration):
-                            next(self.iterable)
+                    def it_raises(self):
+                        with self.assertRaisesWithMessage(
+                            UndefinedBehaviorForCall, "No more values to return!"
+                        ):
+                            self.callable_target(*self.call_args, **self.call_kwargs)
 
-        @context.sub_context(".to_raise(exception)")
-        def to_raise_exception(context):
+            if can_yield:
 
-            context.memoize("exception_class", lambda _: RuntimeError)
-            context.memoize("times", lambda _: 3)
+                @context.sub_context(".to_yield_values(values_list)")
+                def to_yield_values_values_list(context):
 
-            @context.shared_context
-            def integration(context):
-                @context.before
-                def catch_callable_target_exceptions(self):
-                    original_callable_target = self.callable_target
+                    context.memoize(
+                        "values_list", lambda _: ["first", "second", "third"]
+                    )
+                    context.memoize("times", lambda self: len(self.values_list) - 1)
 
-                    def _callable_target(*args, **kwargs):
+                    @context.before
+                    def setup_mock(self):
+                        self.mock_callable_dsl.to_yield_values(self.values_list)
+
+                    if has_original_callable:
+                        context.nest_context("mock call arguments")
+                    context.nest_context("assertions")
+
+                    @context.memoize
+                    def iterable(self):
+                        return iter(
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+                        )
+
+                    @context.example
+                    def yield_values_from_list_in_order(self):
+                        for value in self.values_list:
+                            self.assertEqual(next(self.iterable), value)
+
+                    @context.sub_context
+                    def when_list_is_empty(context):
+                        @context.before
+                        def before(self):
+                            for _ in self.values_list:
+                                next(self.iterable)
+
+                        @context.example
+                        def it_raises_StopIteration(self):
+                            with self.assertRaises(StopIteration):
+                                next(self.iterable)
+
+            @context.sub_context(".to_raise(exception)")
+            def to_raise_exception(context):
+
+                context.memoize("exception_class", lambda _: RuntimeError)
+                context.memoize("times", lambda _: 3)
+
+                @context.shared_context
+                def integration(context):
+                    @context.before
+                    def catch_callable_target_exceptions(self):
+                        original_callable_target = self.callable_target
+
+                        def _callable_target(*args, **kwargs):
+                            with self.assertRaises(self.exception_class):
+                                return original_callable_target(*args, **kwargs)
+
+                        self.callable_target = _callable_target
+
+                    if has_original_callable:
+                        context.nest_context("mock call arguments")
+                    context.nest_context("assertions")
+
+                @context.sub_context
+                def when_given_an_exception_class(context):
+                    @context.before
+                    def setup_mock(self):
+                        self.mock_callable_dsl.to_raise(self.exception_class)
+
+                    @context.example
+                    def it_raises_an_instance_of_the_class(self):
                         with self.assertRaises(self.exception_class):
-                            return original_callable_target(*args, **kwargs)
+                            self.callable_target(*self.call_args, **self.call_kwargs)
 
-                    self.callable_target = _callable_target
+                    context.nest_context("integration")
+
+                @context.sub_context
+                def when_given_an_exception_instance(context):
+
+                    context.memoize("exception_message", lambda _: "test exception")
+                    context.memoize(
+                        "exception",
+                        lambda self: self.exception_class(self.exception_message),
+                    )
+
+                    @context.before
+                    def setup_mock(self):
+                        self.mock_callable_dsl.to_raise(self.exception)
+
+                    @context.example
+                    def it_raises_the_exception_instance(self):
+                        with self.assertRaises(self.exception_class) as cm:
+                            self.callable_target(*self.call_args, **self.call_kwargs)
+                        self.assertEqual(self.exception, cm.exception)
+
+                    context.nest_context("integration")
+
+            @context.sub_context(".with_implementation(func)")
+            def with_implementation_func(context):
+
+                context.memoize("times", lambda _: 3)
+                context.memoize("func_return", lambda _: "mocked response")
+
+                @context.memoize
+                def func(self):
+                    def _func(*args, **kwargs):
+                        return self.func_return
+
+                    return _func
+
+                @context.before
+                def setup_mock(self):
+                    self.mock_callable_dsl.with_implementation(self.func)
 
                 if has_original_callable:
                     context.nest_context("mock call arguments")
                 context.nest_context("assertions")
 
-            @context.sub_context
-            def when_given_an_exception_class(context):
-                @context.before
-                def setup_mock(self):
-                    self.mock_callable_dsl.to_raise(self.exception_class)
-
                 @context.example
-                def it_raises_an_instance_of_the_class(self):
-                    with self.assertRaises(self.exception_class):
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-
-                context.nest_context("integration")
-
-            @context.sub_context
-            def when_given_an_exception_instance(context):
-
-                context.memoize("exception_message", lambda _: "test exception")
-                context.memoize(
-                    "exception",
-                    lambda self: self.exception_class(self.exception_message),
-                )
-
-                @context.before
-                def setup_mock(self):
-                    self.mock_callable_dsl.to_raise(self.exception)
-
-                @context.example
-                def it_raises_the_exception_instance(self):
-                    with self.assertRaises(self.exception_class) as cm:
-                        self.callable_target(*self.call_args, **self.call_kwargs)
-                    self.assertEqual(self.exception, cm.exception)
-
-                context.nest_context("integration")
-
-        @context.sub_context(".with_implementation(func)")
-        def with_implementation_func(context):
-
-            context.memoize("times", lambda _: 3)
-            context.memoize("func_return", lambda _: "mocked response")
-
-            @context.memoize
-            def func(self):
-                def _func(*args, **kwargs):
-                    return self.func_return
-
-                return _func
-
-            @context.before
-            def setup_mock(self):
-                self.mock_callable_dsl.with_implementation(self.func)
-
-            if has_original_callable:
-                context.nest_context("mock call arguments")
-            context.nest_context("assertions")
-
-            @context.example
-            def it_calls_new_implementation(self):
-                self.assertEqual(
-                    self.callable_target(*self.call_args, **self.call_kwargs),
-                    self.func_return,
-                )
-
-        @context.sub_context(".with_wrapper(wrapper_func)")
-        def with_wrapper_wrappr_func(context):
-
-            context.memoize("func_return", lambda _: "mocked response")
-
-            @context.memoize
-            def wrapper_func(self):
-                def _wrapper_func(original_function, *args, **kwargs):
-                    self.assertEqual(original_function, self.original_callable)
-                    return self.func_return
-
-                return _wrapper_func
-
-            if has_original_callable:
-
-                context.memoize("times", lambda _: 3)
-
-                @context.before
-                def setup_mock(self):
-                    self.mock_callable_dsl.with_wrapper(self.wrapper_func)
-
-                context.nest_context("mock call arguments")
-                context.nest_context("assertions")
-
-                @context.example
-                def it_calls_wrapper_function(self):
+                def it_calls_new_implementation(self):
                     self.assertEqual(
                         self.callable_target(*self.call_args, **self.call_kwargs),
                         self.func_return,
                     )
 
-            else:
+            @context.sub_context(".with_wrapper(wrapper_func)")
+            def with_wrapper_wrappr_func(context):
 
-                @context.example
-                def it_fails_to_mock(self):
-                    with self.assertRaisesWithMessage(
-                        ValueError,
-                        "Can not wrap original callable that does not exist.",
-                    ):
+                context.memoize("func_return", lambda _: "mocked response")
+
+                @context.memoize
+                def wrapper_func(self):
+                    def _wrapper_func(original_function, *args, **kwargs):
+                        self.assertEqual(original_function, self.original_callable)
+                        return self.func_return
+
+                    return _wrapper_func
+
+                if has_original_callable:
+
+                    context.memoize("times", lambda _: 3)
+
+                    @context.before
+                    def setup_mock(self):
                         self.mock_callable_dsl.with_wrapper(self.wrapper_func)
 
-        @context.sub_context(".to_call_original()")
-        def to_call_original(context):
+                    context.nest_context("mock call arguments")
+                    context.nest_context("assertions")
 
-            if has_original_callable:
+                    @context.example
+                    def it_calls_wrapper_function(self):
+                        self.assertEqual(
+                            self.callable_target(*self.call_args, **self.call_kwargs),
+                            self.func_return,
+                        )
 
-                context.memoize("times", lambda _: 3)
+                else:
 
-                @context.before
-                def setup_mock(self):
-                    self.mock_callable_dsl.to_call_original()
+                    @context.example
+                    def it_fails_to_mock(self):
+                        with self.assertRaisesWithMessage(
+                            ValueError,
+                            "Can not wrap original callable that does not exist.",
+                        ):
+                            self.mock_callable_dsl.with_wrapper(self.wrapper_func)
 
-                context.nest_context("mock call arguments")
-                context.nest_context("assertions")
+            @context.sub_context(".to_call_original()")
+            def to_call_original(context):
 
-                @context.example
-                def it_calls_original_implementation(self):
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs),
-                        self.original_callable(*self.call_args, **self.call_kwargs),
-                    )
+                if has_original_callable:
 
-            else:
+                    context.memoize("times", lambda _: 3)
 
-                @context.example
-                def it_fails_to_mock(self):
-                    with self.assertRaisesWithMessage(
-                        ValueError,
-                        "Can not call original callable that does not exist.",
-                    ):
+                    @context.before
+                    def setup_mock(self):
                         self.mock_callable_dsl.to_call_original()
 
-        if not callable_accepts_no_args:
+                    context.nest_context("mock call arguments")
+                    context.nest_context("assertions")
 
-            @context.sub_context
-            def composition(context):
-                """
-                This context takes care of composition of multiple
-                call/behavior/assertion combination, to ensure they play along well.
-                """
+                    @context.example
+                    def it_calls_original_implementation(self):
+                        self.assertEqual(
+                            self.callable_target(*self.call_args, **self.call_kwargs),
+                            self.original_callable(*self.call_args, **self.call_kwargs),
+                        )
 
-                context.memoize(
-                    "other_args", lambda self: ["other_arg" for arg in self.call_args]
-                )
-                context.memoize(
-                    "other_kwargs",
-                    lambda self: {
-                        k: "other_value" for k, v in self.call_kwargs.items()
-                    },
-                )
+                else:
 
-                @context.example
-                def newest_mock_has_precedence_over_older_mocks(self):
-                    """
-                    Mocks are designed to be composable, allowing us to declare
-                    multiple behaviors for different calls. Those definitions stack up,
-                    and when a call is made to the mock, they are searched from newest
-                    to oldest, to find one that is able to be caled.
-                    """
-                    # First, mock all calls
-                    mock_callable(self.target_arg, self.callable_arg).to_return_value(
-                        "any args"
-                    )
-                    # Then we add some specific call behavior
-                    mock_callable(self.target_arg, self.callable_arg).for_call(
-                        *self.specific_call_args, **self.specific_call_kwargs
-                    ).to_return_value("specific")
-                    # The first behavior should still be there
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs),
-                        "any args",
-                    )
-                    # as well as the specific case
-                    self.assertEqual(
-                        self.callable_target(
-                            *self.specific_call_args, **self.specific_call_kwargs
-                        ),
-                        "specific",
-                    )
-                    # but if we add another "catch all" case
-                    mock_callable(self.target_arg, self.callable_arg).to_return_value(
-                        "new any args"
-                    )
-                    # it should take over any previous mock
-                    self.assertEqual(
-                        self.callable_target(*self.call_args, **self.call_kwargs),
-                        "new any args",
-                    )
-                    self.assertEqual(
-                        self.callable_target(
-                            *self.specific_call_args, **self.specific_call_kwargs
-                        ),
-                        "new any args",
-                    )
+                    @context.example
+                    def it_fails_to_mock(self):
+                        with self.assertRaisesWithMessage(
+                            ValueError,
+                            "Can not call original callable that does not exist.",
+                        ):
+                            self.mock_callable_dsl.to_call_original()
+
+            if not callable_accepts_no_args:
 
                 @context.sub_context
-                def multiple_assertions(context):
-                    @context.before
-                    def setup_mocks(self):
+                def composition(context):
+                    """
+                    This context takes care of composition of multiple
+                    call/behavior/assertion combination, to ensure they play along well.
+                    """
+
+                    context.memoize(
+                        "other_args",
+                        lambda self: ["other_arg" for arg in self.call_args],
+                    )
+                    context.memoize(
+                        "other_kwargs",
+                        lambda self: {
+                            k: "other_value" for k, v in self.call_kwargs.items()
+                        },
+                    )
+
+                    @context.example
+                    def newest_mock_has_precedence_over_older_mocks(self):
+                        """
+                        Mocks are designed to be composable, allowing us to declare
+                        multiple behaviors for different calls. Those definitions stack up,
+                        and when a call is made to the mock, they are searched from newest
+                        to oldest, to find one that is able to be caled.
+                        """
+                        # First, mock all calls
                         mock_callable(
                             self.target_arg, self.callable_arg
-                        ).to_return_value("any args").and_assert_called_once()
+                        ).to_return_value("any args")
+                        # Then we add some specific call behavior
                         mock_callable(self.target_arg, self.callable_arg).for_call(
                             *self.specific_call_args, **self.specific_call_kwargs
-                        ).to_return_value("specific").and_assert_called_twice()
-
-                    @context.example
-                    def that_passes(self):
-                        self.callable_target(*self.other_args, **self.other_kwargs)
-                        self.callable_target(
-                            *self.specific_call_args, **self.specific_call_kwargs
+                        ).to_return_value("specific")
+                        # The first behavior should still be there
+                        self.assertEqual(
+                            self.callable_target(*self.call_args, **self.call_kwargs),
+                            "any args",
                         )
-                        self.callable_target(
-                            *self.specific_call_args, **self.specific_call_kwargs
+                        # as well as the specific case
+                        self.assertEqual(
+                            self.callable_target(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            ),
+                            "specific",
+                        )
+                        # but if we add another "catch all" case
+                        mock_callable(
+                            self.target_arg, self.callable_arg
+                        ).to_return_value("new any args")
+                        # it should take over any previous mock
+                        self.assertEqual(
+                            self.callable_target(*self.call_args, **self.call_kwargs),
+                            "new any args",
+                        )
+                        self.assertEqual(
+                            self.callable_target(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            ),
+                            "new any args",
                         )
 
-                    @context.example
-                    def that_fails(self):
-                        # "Pass" this test when callable accepts no arguments
-                        if (
-                            self.specific_call_args == self.call_args
-                            and self.specific_call_kwargs == self.call_kwargs
-                        ):
-                            raise RuntimeError("FIXME")
-                            return
-                        self.callable_target(*self.other_args, **self.other_kwargs)
-                        self.callable_target(
-                            *self.specific_call_args, **self.specific_call_kwargs
-                        )
-                        with self.assertRaises(AssertionError):
-                            self.assert_all()
+                    @context.sub_context
+                    def multiple_assertions(context):
+                        @context.before
+                        def setup_mocks(self):
+                            mock_callable(
+                                self.target_arg, self.callable_arg
+                            ).to_return_value("any args").and_assert_called_once()
+                            mock_callable(self.target_arg, self.callable_arg).for_call(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            ).to_return_value("specific").and_assert_called_twice()
 
-    @context.shared_context
-    def class_is_not_mocked(context):
-        @context.example
-        def class_is_not_mocked(self):
-            mock_callable(self.target_arg, self.callable_arg).to_return_value(
-                "mocked value"
-            )
-            self.assertEqual(
-                self.callable_target(*self.call_args, **self.call_kwargs),
-                "mocked value",
-            )
-            self.assertEqual(
-                getattr(Target, self.callable_arg)(*self.call_args, **self.call_kwargs),
-                "original response",
-            )
+                        @context.example
+                        def that_passes(self):
+                            self.callable_target(*self.other_args, **self.other_kwargs)
+                            self.callable_target(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            )
+                            self.callable_target(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            )
 
-    @context.shared_context
-    def can_not_mock_async_callable(context):
-        @context.example
-        def can_not_mock(self):
-            with self.assertRaisesRegex(
-                ValueError,
-                "mock_callable\(\) can not be used with coroutine functions\.",
-            ):
-                mock_callable(self.target_arg, self.callable_arg)
-
-    @context.shared_context
-    def async_methods_examples(context):
-        @context.sub_context
-        def and_callable_is_an_async_instance_method(context):
-            context.memoize("callable_arg", lambda _: "async_instance_method")
-
-            context.merge_context("can not mock async callable")
-
-        @context.sub_context
-        def and_callable_is_an_async_class_method(context):
-            context.memoize("callable_arg", lambda _: "async_class_method")
-
-            context.merge_context("can not mock async callable")
-
-        @context.sub_context
-        def and_callable_is_an_async_static_method(context):
-            context.memoize("callable_arg", lambda _: "async_static_method")
-
-            context.merge_context("can not mock async callable")
-
-        @context.sub_context
-        def and_callable_is_an_async_magic_method(context):
-            context.memoize("callable_arg", lambda _: "__aiter__")
-
-            context.merge_context("can not mock async callable")
-
-    ##
-    ## Contexts
-    ##
-
-    @context.sub_context
-    def call_order_assertion(context):
-        @context.memoize
-        def target1(self):
-            return CallOrderTarget("target1")
-
-        @context.memoize
-        def target2(self):
-            return CallOrderTarget("target2")
-
-        @context.before
-        def define_assertions(self):
-            self.mock_callable(self.target1, "f1").for_call("step 1").to_return_value(
-                "step 1 return"
-            ).and_assert_called_ordered()
-            self.mock_callable(self.target1, "f2").to_return_value(
-                "step 2 return"
-            ).and_assert_called_ordered()
-            self.mock_callable(self.target2, "f1").for_call("step 3").to_return_value(
-                "step 3 return"
-            ).and_assert_called_ordered()
-
-        @context.example
-        def it_passes_with_ordered_calls(self):
-            self.assertEqual(self.target1.f1("step 1"), "step 1 return")
-            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-            self.assert_all()
-
-        @context.example
-        def it_fails_with_unordered_calls(self):
-            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-            self.assertEqual(self.target1.f1("step 1"), "step 1 return")
-            with self.assertRaisesWithMessage(
-                AssertionError,
-                "calls did not match assertion.\n"
-                + "\n"
-                + "These calls were expected to have happened in order:\n"
-                + "\n"
-                + "  target1, {} with arguments:\n".format(repr("f1"))
-                + "    {}\n".format(repr(("step 1",)))
-                + "  target1, {} with any arguments\n".format(repr("f2"))
-                + "  target2, {} with arguments:\n".format(repr("f1"))
-                + "    {}\n".format(repr(("step 3",)))
-                + "\n"
-                + "but these calls were made:\n"
-                + "\n"
-                + "  target1, {} with any arguments\n".format(repr("f2"))
-                + "  target2, {} with arguments:\n".format(repr("f1"))
-                + "    {}\n".format(repr(("step 3",)))
-                + "  target1, {} with arguments:\n".format(repr("f1"))
-                + "    {}".format(repr(("step 1",))),
-            ):
-                self.assert_all()
-
-        @context.example
-        def it_fails_with_partial_calls(self):
-            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-            with self.assertRaisesWithMessage(
-                AssertionError,
-                "calls did not match assertion.\n"
-                + "\n"
-                + "These calls were expected to have happened in order:\n"
-                + "\n"
-                + "  target1, {} with arguments:\n".format(repr("f1"))
-                + "    {}\n".format(repr(("step 1",)))
-                + "  target1, {} with any arguments\n".format(repr("f2"))
-                + "  target2, {} with arguments:\n".format(repr("f1"))
-                + "    {}\n".format(repr(("step 3",)))
-                + "\n"
-                + "but these calls were made:\n"
-                + "\n"
-                + "  target1, {} with any arguments\n".format(repr("f2"))
-                + "  target2, {} with arguments:\n".format(repr("f1"))
-                + "    {}".format(repr(("step 3",))),
-            ):
-                self.assert_all()
-
-        @context.example
-        def other_mocks_do_not_interfere(self):
-            self.mock_callable(self.target1, "f1").for_call(
-                "unrelated 1"
-            ).to_return_value("unrelated 1 return").and_assert_called_once()
-
-            self.assertEqual(self.target1.f1("unrelated 1"), "unrelated 1 return")
-
-            self.mock_callable(self.target2, "f1").for_call(
-                "unrelated 3"
-            ).to_return_value("unrelated 3 return")
-
-            self.assertEqual(self.target1.f1("step 1"), "step 1 return")
-            self.assertEqual(self.target1.f2("step 2"), "step 2 return")
-            self.assertEqual(self.target2.f1("step 3"), "step 3 return")
-            self.assert_all()
-
-    @context.sub_context
-    def when_target_is_a_module(context):
-        context.memoize("target_arg", lambda _: "tests.sample_module")
-        context.memoize("real_target", lambda _: sample_module)
-
-        @context.example
-        def works_with_alternative_module_names(self):
-            target = "os.path"
-            target_module = os.path
-            alternative_target = "testslide.cli.os.path"
-            import testslide.cli
-
-            alternative_target_module = testslide.cli.os.path
-            original_function = os.path.exists
-
-            self.mock_callable(target, "exists").for_call("found").to_return_value(True)
-            self.mock_callable(alternative_target, "exists").for_call(
-                "not_found"
-            ).to_return_value(False)
-            self.assertTrue(target_module.exists("found"))
-            self.assertTrue(alternative_target_module.exists("found"))
-            self.assertFalse(target_module.exists("not_found"))
-            self.assertFalse(alternative_target_module.exists("not_found"))
-            testslide.mock_callable.unpatch_all_callable_mocks()
-            self.assertEqual(os.path.exists, original_function, "Unpatch did not work")
-
-        @context.sub_context
-        def and_callable_is_a_function(context):
-            @context.before
-            def before(self):
-                self.callable_arg = "test_function"
-                self.original_callable = getattr(self.real_target, self.callable_arg)
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
-                )
-                self.callable_target = getattr(self.real_target, self.callable_arg)
-
-            context.merge_context("examples for target")
-
-        @context.sub_context
-        def and_callable_is_an_async_function(context):
-            context.memoize("callable_arg", lambda _: "async_test_function")
-
-            context.merge_context("can not mock async callable")
-
-    @context.sub_context
-    def when_target_is_a_class(context):
-        @context.before
-        def before(self):
-            self.real_target = Target
-            self.target_arg = Target
-
-        context.merge_context("async methods examples")
-
-        @context.sub_context
-        def and_callable_is_an_instance_method(context):
-            @context.example
-            def it_is_not_allowed(self):
-                with self.assertRaises(ValueError):
-                    mock_callable(Target, "instance_method")
-
-        @context.sub_context
-        def and_callable_is_a_class_method(context):
-            @context.before
-            def before(self):
-                self.original_callable = Target.class_method
-                self.callable_arg = "class_method"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
-                )
-                self.callable_target = Target.class_method
-
-            context.merge_context("examples for target")
-
-        @context.sub_context
-        def and_callable_is_a_static_method(context):
-            @context.before
-            def before(self):
-                self.original_callable = Target.static_method
-                self.callable_arg = "static_method"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
-                )
-                self.callable_target = Target.static_method
-
-            context.merge_context("examples for target")
-
-        @context.sub_context
-        def and_callable_is_a_magic_method(context):
-            @context.example
-            def it_is_not_allowed(self):
-                with self.assertRaises(ValueError):
-                    mock_callable(Target, "__str__")
-
-    @context.sub_context
-    def an_instance(context):
-        @context.before
-        def before(self):
-            target = Target()
-            self.real_target = target
-            self.target_arg = target
-
-        context.merge_context("async methods examples")
+                        @context.example
+                        def that_fails(self):
+                            # "Pass" this test when callable accepts no arguments
+                            if (
+                                self.specific_call_args == self.call_args
+                                and self.specific_call_kwargs == self.call_kwargs
+                            ):
+                                raise RuntimeError("FIXME")
+                                return
+                            self.callable_target(*self.other_args, **self.other_kwargs)
+                            self.callable_target(
+                                *self.specific_call_args, **self.specific_call_kwargs
+                            )
+                            with self.assertRaises(AssertionError):
+                                self.assert_all()
 
         @context.shared_context
-        def other_instances_are_not_mocked(context):
+        def class_is_not_mocked(context):
             @context.example
-            def other_instances_are_not_mocked(self):
+            def class_is_not_mocked(self):
                 mock_callable(self.target_arg, self.callable_arg).to_return_value(
                     "mocked value"
                 )
@@ -1089,226 +850,841 @@ def mock_callable_context(context):
                     "mocked value",
                 )
                 self.assertEqual(
-                    getattr(Target(), self.callable_arg)(
+                    getattr(Target, self.callable_arg)(
                         *self.call_args, **self.call_kwargs
                     ),
                     "original response",
                 )
 
-        @context.sub_context
-        def and_callable_is_an_instance_method(context):
+        @context.shared_context
+        def can_not_mock_async_callable(context):
+            @context.example
+            def can_not_mock(self):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "mock_callable\(\) can not be used with coroutine functions\.",
+                ):
+                    mock_callable(self.target_arg, self.callable_arg)
 
-            context.memoize("callable_arg", lambda _: "instance_method")
+        @context.shared_context
+        def async_methods_examples(context):
+            @context.sub_context
+            def and_callable_is_an_async_instance_method(context):
+                context.memoize("callable_arg", lambda _: "async_instance_method")
+
+                context.merge_context("can not mock async callable")
+
+            @context.sub_context
+            def and_callable_is_an_async_class_method(context):
+                context.memoize("callable_arg", lambda _: "async_class_method")
+
+                context.merge_context("can not mock async callable")
+
+            @context.sub_context
+            def and_callable_is_an_async_static_method(context):
+                context.memoize("callable_arg", lambda _: "async_static_method")
+
+                context.merge_context("can not mock async callable")
+
+            @context.sub_context
+            def and_callable_is_an_async_magic_method(context):
+                context.memoize("callable_arg", lambda _: "__aiter__")
+
+                context.merge_context("can not mock async callable")
+
+        ##
+        ## Contexts
+        ##
+
+        @context.sub_context
+        def call_order_assertion(context):
+            @context.memoize
+            def target1(self):
+                return CallOrderTarget("target1")
+
+            @context.memoize
+            def target2(self):
+                return CallOrderTarget("target2")
 
             @context.before
-            def before(self):
-                self.original_callable = self.real_target.instance_method
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
-                )
-                self.callable_target = self.real_target.instance_method
+            def define_assertions(self):
+                self.mock_callable(self.target1, "f1").for_call(
+                    "step 1"
+                ).to_return_value("step 1 return").and_assert_called_ordered()
+                self.mock_callable(self.target1, "f2").to_return_value(
+                    "step 2 return"
+                ).and_assert_called_ordered()
+                self.mock_callable(self.target2, "f1").for_call(
+                    "step 3"
+                ).to_return_value("step 3 return").and_assert_called_ordered()
 
-            context.merge_context("examples for target")
-            context.merge_context("other instances are not mocked")
+            @context.example
+            def it_passes_with_ordered_calls(self):
+                self.assertEqual(self.target1.f1("step 1"), "step 1 return")
+                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+                self.assert_all()
+
+            @context.example
+            def it_fails_with_unordered_calls(self):
+                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+                self.assertEqual(self.target1.f1("step 1"), "step 1 return")
+                with self.assertRaisesWithMessage(
+                    AssertionError,
+                    "calls did not match assertion.\n"
+                    + "\n"
+                    + "These calls were expected to have happened in order:\n"
+                    + "\n"
+                    + "  target1, {} with arguments:\n".format(repr("f1"))
+                    + "    {}\n".format(repr(("step 1",)))
+                    + "  target1, {} with any arguments\n".format(repr("f2"))
+                    + "  target2, {} with arguments:\n".format(repr("f1"))
+                    + "    {}\n".format(repr(("step 3",)))
+                    + "\n"
+                    + "but these calls were made:\n"
+                    + "\n"
+                    + "  target1, {} with any arguments\n".format(repr("f2"))
+                    + "  target2, {} with arguments:\n".format(repr("f1"))
+                    + "    {}\n".format(repr(("step 3",)))
+                    + "  target1, {} with arguments:\n".format(repr("f1"))
+                    + "    {}".format(repr(("step 1",))),
+                ):
+                    self.assert_all()
+
+            @context.example
+            def it_fails_with_partial_calls(self):
+                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+                with self.assertRaisesWithMessage(
+                    AssertionError,
+                    "calls did not match assertion.\n"
+                    + "\n"
+                    + "These calls were expected to have happened in order:\n"
+                    + "\n"
+                    + "  target1, {} with arguments:\n".format(repr("f1"))
+                    + "    {}\n".format(repr(("step 1",)))
+                    + "  target1, {} with any arguments\n".format(repr("f2"))
+                    + "  target2, {} with arguments:\n".format(repr("f1"))
+                    + "    {}\n".format(repr(("step 3",)))
+                    + "\n"
+                    + "but these calls were made:\n"
+                    + "\n"
+                    + "  target1, {} with any arguments\n".format(repr("f2"))
+                    + "  target2, {} with arguments:\n".format(repr("f1"))
+                    + "    {}".format(repr(("step 3",))),
+                ):
+                    self.assert_all()
+
+            @context.example
+            def other_mocks_do_not_interfere(self):
+                self.mock_callable(self.target1, "f1").for_call(
+                    "unrelated 1"
+                ).to_return_value("unrelated 1 return").and_assert_called_once()
+
+                self.assertEqual(self.target1.f1("unrelated 1"), "unrelated 1 return")
+
+                self.mock_callable(self.target2, "f1").for_call(
+                    "unrelated 3"
+                ).to_return_value("unrelated 3 return")
+
+                self.assertEqual(self.target1.f1("step 1"), "step 1 return")
+                self.assertEqual(self.target1.f2("step 2"), "step 2 return")
+                self.assertEqual(self.target2.f1("step 3"), "step 3 return")
+                self.assert_all()
 
         @context.sub_context
-        def and_callable_is_a_class_method(context):
-            @context.before
-            def before(self):
-                self.original_callable = self.real_target.class_method
-                self.callable_arg = "class_method"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
+        def when_target_is_a_module(context):
+            context.memoize("target_arg", lambda _: "tests.sample_module")
+            context.memoize("real_target", lambda _: sample_module)
+
+            @context.example
+            def works_with_alternative_module_names(self):
+                target = "os.path"
+                target_module = os.path
+                alternative_target = "testslide.cli.os.path"
+                import testslide.cli
+
+                alternative_target_module = testslide.cli.os.path
+                original_function = os.path.exists
+
+                self.mock_callable(target, "exists").for_call("found").to_return_value(
+                    True
                 )
-                self.callable_target = self.real_target.class_method
-
-            context.merge_context("examples for target")
-            context.merge_context("other instances are not mocked")
-            context.merge_context("class is not mocked")
-
-        @context.sub_context
-        def and_callable_is_a_static_method(context):
-            @context.before
-            def before(self):
-                self.original_callable = self.real_target.static_method
-                self.callable_arg = "static_method"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
+                self.mock_callable(alternative_target, "exists").for_call(
+                    "not_found"
+                ).to_return_value(False)
+                self.assertTrue(target_module.exists("found"))
+                self.assertTrue(alternative_target_module.exists("found"))
+                self.assertFalse(target_module.exists("not_found"))
+                self.assertFalse(alternative_target_module.exists("not_found"))
+                testslide.mock_callable.unpatch_all_callable_mocks()
+                self.assertEqual(
+                    os.path.exists, original_function, "Unpatch did not work"
                 )
-                self.callable_target = self.real_target.static_method
 
-            context.merge_context("examples for target")
-            context.merge_context("other instances are not mocked")
-            context.merge_context("class is not mocked")
-
-        @context.sub_context
-        def and_callable_is_a_magic_method(context):
-            context.memoize("call_args", lambda _: ())
-            context.memoize("call_kwargs", lambda _: {})
-
-            @context.shared_context
-            def magic_method_tests(context):
+            @context.sub_context
+            def and_callable_is_a_function(context):
                 @context.before
                 def before(self):
-                    self.original_callable = self.target.__str__
-                    self.real_target = self.target
-                    self.target_arg = self.target
-                    self.callable_arg = "__str__"
+                    self.callable_arg = "test_function"
+                    self.original_callable = getattr(
+                        self.real_target, self.callable_arg
+                    )
                     self.mock_callable_dsl = mock_callable(
                         self.target_arg, self.callable_arg
                     )
-                    self.callable_target = lambda: str(self.target)
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
 
-                context.merge_context(
-                    "examples for target",
-                    callable_accepts_no_args=True,
-                    can_yield=False,
-                )
+                context.merge_context("mock configuration examples")
 
+            @context.sub_context
+            def and_callable_is_an_async_function(context):
+                context.memoize("callable_arg", lambda _: "async_test_function")
+
+                context.merge_context("can not mock async callable")
+
+        @context.sub_context
+        def when_target_is_a_class(context):
+            @context.before
+            def before(self):
+                self.real_target = Target
+                self.target_arg = Target
+
+            context.merge_context("async methods examples")
+
+            @context.sub_context
+            def and_callable_is_an_instance_method(context):
+                @context.example
+                def it_is_not_allowed(self):
+                    with self.assertRaises(ValueError):
+                        mock_callable(Target, "instance_method")
+
+            @context.sub_context
+            def and_callable_is_a_class_method(context):
+                @context.before
+                def before(self):
+                    self.original_callable = Target.class_method
+                    self.callable_arg = "class_method"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = Target.class_method
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_a_static_method(context):
+                @context.before
+                def before(self):
+                    self.original_callable = Target.static_method
+                    self.callable_arg = "static_method"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = Target.static_method
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_a_magic_method(context):
+                @context.example
+                def it_is_not_allowed(self):
+                    with self.assertRaises(ValueError):
+                        mock_callable(Target, "__str__")
+
+        @context.sub_context
+        def an_instance(context):
+            @context.before
+            def before(self):
+                target = Target()
+                self.real_target = target
+                self.target_arg = target
+
+            context.merge_context("async methods examples")
+
+            @context.shared_context
+            def other_instances_are_not_mocked(context):
                 @context.example
                 def other_instances_are_not_mocked(self):
                     mock_callable(self.target_arg, self.callable_arg).to_return_value(
                         "mocked value"
                     )
-                    self.assertEqual(self.callable_target(), "mocked value")
-                    self.assertEqual(str(Target()), "original response")
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs),
+                        "mocked value",
+                    )
+                    self.assertEqual(
+                        getattr(Target(), self.callable_arg)(
+                            *self.call_args, **self.call_kwargs
+                        ),
+                        "original response",
+                    )
 
             @context.sub_context
-            def with_magic_method_defined_on_class(context):
-                context.memoize("target", lambda self: ParentTarget())
-                context.merge_context("magic method tests")
+            def and_callable_is_an_instance_method(context):
 
-            @context.sub_context
-            def with_magic_method_defined_on_parent_class(context):
-                context.memoize("target", lambda self: Target())
-                context.merge_context("magic method tests")
+                context.memoize("callable_arg", lambda _: "instance_method")
 
-    @context.sub_context
-    def when_target_is_a_StrictMock(context):
-        @context.before
-        def before(self):
-            target = StrictMock(template=Target)
-            self.original_callable = None
-            self.real_target = target
-            self.target_arg = target
-
-        context.merge_context("async methods examples")
-
-        @context.shared_context
-        def other_instances_are_not_mocked(context, runtime_attrs=[]):
-            @context.example
-            def other_instances_are_not_mocked(self):
-                mock_callable(self.target_arg, self.callable_arg).to_return_value(
-                    "mocked value"
-                )
-                self.assertEqual(
-                    self.callable_target(*self.call_args, **self.call_kwargs),
-                    "mocked value",
-                )
-                other_strict_mock = StrictMock(
-                    template=Target, runtime_attrs=runtime_attrs
-                )
-                mock_callable(other_strict_mock, self.callable_arg).to_return_value(
-                    "other mocked value"
-                )
-                self.assertEqual(
-                    getattr(other_strict_mock, self.callable_arg)(
-                        *self.call_args, **self.call_kwargs
-                    ),
-                    "other mocked value",
-                )
-
-        @context.sub_context
-        def and_callable_is_an_instance_method(context):
-            context.memoize("callable_arg", lambda _: "instance_method")
-
-            @context.sub_context
-            def that_is_statically_defined_at_the_class(context):
                 @context.before
                 def before(self):
+                    self.original_callable = self.real_target.instance_method
                     self.mock_callable_dsl = mock_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = self.real_target.instance_method
 
-                context.merge_context(
-                    "examples for target", has_original_callable=False
-                )
-
+                context.merge_context("mock configuration examples")
                 context.merge_context("other instances are not mocked")
 
             @context.sub_context
-            def that_is_dynamically_defined_by_the_instance(context):
-
-                context.memoize("callable_arg", lambda _: "dynamic_instance_method")
-
+            def and_callable_is_a_class_method(context):
                 @context.before
                 def before(self):
-                    target = StrictMock(
-                        template=Target, runtime_attrs=["dynamic_instance_method"]
-                    )
-                    self.original_callable = None
-                    self.real_target = target
-                    self.target_arg = target
+                    self.original_callable = self.real_target.class_method
+                    self.callable_arg = "class_method"
                     self.mock_callable_dsl = mock_callable(
                         self.target_arg, self.callable_arg
                     )
-                    self.callable_target = target.dynamic_instance_method
+                    self.callable_target = self.real_target.class_method
+
+                context.merge_context("mock configuration examples")
+                context.merge_context("other instances are not mocked")
+                context.merge_context("class is not mocked")
+
+            @context.sub_context
+            def and_callable_is_a_static_method(context):
+                @context.before
+                def before(self):
+                    self.original_callable = self.real_target.static_method
+                    self.callable_arg = "static_method"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = self.real_target.static_method
+
+                context.merge_context("mock configuration examples")
+                context.merge_context("other instances are not mocked")
+                context.merge_context("class is not mocked")
+
+            @context.sub_context
+            def and_callable_is_a_magic_method(context):
+                context.memoize("call_args", lambda _: ())
+                context.memoize("call_kwargs", lambda _: {})
+
+                @context.shared_context
+                def magic_method_tests(context):
+                    @context.before
+                    def before(self):
+                        self.original_callable = self.target.__str__
+                        self.real_target = self.target
+                        self.target_arg = self.target
+                        self.callable_arg = "__str__"
+                        self.mock_callable_dsl = mock_callable(
+                            self.target_arg, self.callable_arg
+                        )
+                        self.callable_target = lambda: str(self.target)
+
+                    context.merge_context(
+                        "mock configuration examples",
+                        callable_accepts_no_args=True,
+                        can_yield=False,
+                    )
+
+                    @context.example
+                    def other_instances_are_not_mocked(self):
+                        mock_callable(
+                            self.target_arg, self.callable_arg
+                        ).to_return_value("mocked value")
+                        self.assertEqual(self.callable_target(), "mocked value")
+                        self.assertEqual(str(Target()), "original response")
+
+                @context.sub_context
+                def with_magic_method_defined_on_class(context):
+                    context.memoize("target", lambda self: ParentTarget())
+                    context.merge_context("magic method tests")
+
+                @context.sub_context
+                def with_magic_method_defined_on_parent_class(context):
+                    context.memoize("target", lambda self: Target())
+                    context.merge_context("magic method tests")
+
+        @context.sub_context
+        def when_target_is_a_StrictMock(context):
+            @context.before
+            def before(self):
+                target = StrictMock(template=Target)
+                self.original_callable = None
+                self.real_target = target
+                self.target_arg = target
+
+            context.merge_context("async methods examples")
+
+            @context.shared_context
+            def other_instances_are_not_mocked(context, runtime_attrs=[]):
+                @context.example
+                def other_instances_are_not_mocked(self):
+                    mock_callable(self.target_arg, self.callable_arg).to_return_value(
+                        "mocked value"
+                    )
+                    self.assertEqual(
+                        self.callable_target(*self.call_args, **self.call_kwargs),
+                        "mocked value",
+                    )
+                    other_strict_mock = StrictMock(
+                        template=Target, runtime_attrs=runtime_attrs
+                    )
+                    mock_callable(other_strict_mock, self.callable_arg).to_return_value(
+                        "other mocked value"
+                    )
+                    self.assertEqual(
+                        getattr(other_strict_mock, self.callable_arg)(
+                            *self.call_args, **self.call_kwargs
+                        ),
+                        "other mocked value",
+                    )
+
+            @context.sub_context
+            def and_callable_is_an_instance_method(context):
+                context.memoize("callable_arg", lambda _: "instance_method")
+
+                @context.sub_context
+                def that_is_statically_defined_at_the_class(context):
+                    @context.before
+                    def before(self):
+                        self.mock_callable_dsl = mock_callable(
+                            self.target_arg, self.callable_arg
+                        )
+                        self.callable_target = self.real_target.instance_method
+
+                    context.merge_context(
+                        "mock configuration examples", has_original_callable=False
+                    )
+
+                    context.merge_context("other instances are not mocked")
+
+                @context.sub_context
+                def that_is_dynamically_defined_by_the_instance(context):
+
+                    context.memoize("callable_arg", lambda _: "dynamic_instance_method")
+
+                    @context.before
+                    def before(self):
+                        target = StrictMock(
+                            template=Target, runtime_attrs=["dynamic_instance_method"]
+                        )
+                        self.original_callable = None
+                        self.real_target = target
+                        self.target_arg = target
+                        self.mock_callable_dsl = mock_callable(
+                            self.target_arg, self.callable_arg
+                        )
+                        self.callable_target = target.dynamic_instance_method
+
+                    context.merge_context(
+                        "mock configuration examples", has_original_callable=False
+                    )
+
+                    context.merge_context(
+                        "other instances are not mocked",
+                        runtime_attrs=["dynamic_instance_method"],
+                    )
+
+            @context.sub_context
+            def and_callable_is_a_class_method(context):
+                @context.before
+                def before(self):
+                    self.callable_arg = "class_method"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = self.real_target.class_method
 
                 context.merge_context(
-                    "examples for target", has_original_callable=False
+                    "mock configuration examples", has_original_callable=False
                 )
+                context.merge_context("other instances are not mocked")
+                context.merge_context("class is not mocked")
+
+            @context.sub_context
+            def and_callable_is_a_static_method(context):
+                @context.before
+                def before(self):
+                    self.callable_arg = "static_method"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = self.real_target.static_method
 
                 context.merge_context(
-                    "other instances are not mocked",
-                    runtime_attrs=["dynamic_instance_method"],
+                    "mock configuration examples", has_original_callable=False
+                )
+                context.merge_context("other instances are not mocked")
+                context.merge_context("class is not mocked")
+
+            @context.sub_context
+            def and_callable_is_a_magic_method(context):
+                context.memoize("call_args", lambda _: ())
+                context.memoize("call_kwargs", lambda _: {})
+
+                @context.before
+                def before(self):
+                    self.callable_arg = "__str__"
+                    self.mock_callable_dsl = mock_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = lambda: str(self.real_target)
+
+                context.merge_context(
+                    "mock configuration examples",
+                    callable_accepts_no_args=True,
+                    has_original_callable=False,
+                    can_yield=False,
+                )
+                context.merge_context("other instances are not mocked")
+
+    @context.sub_context("mock_async_callable()")
+    def mock_async_callable_tests(context):
+
+        ##
+        ## Shared Contexts
+        ##
+
+        @context.shared_context
+        def mock_async_callable_with_sync_exapmles(context):
+            @context.xexample
+            async def can_not_mock(self):
+                pass
+
+            @context.xexample
+            async def can_mock_with_flag(self):
+                pass
+
+        @context.shared_context
+        def mock_configuration_examples(
+            context,
+            callable_accepts_no_args=False,
+            can_yield=False,
+            has_original_callable=True,
+        ):
+            @context.xexample(".for_call()")
+            async def for_call(self):
+                pass
+
+            @context.xexample(".to_return_value(value)")
+            async def to_return_value(self):
+                pass
+
+            @context.xexample(".to_return_values(value_list)")
+            async def to_return_values(self):
+                pass
+
+            @context.xexample(".to_raise(exception)")
+            async def to_raise(self):
+                pass
+
+            @context.xexample(".with_implementation(func)")
+            async def with_implementation(self):
+                pass
+
+            @context.xexample(".with_wrapper(func)")
+            async def with_wrapper(self):
+                pass
+
+            @context.xexample(".to_call_original()")
+            async def to_call_original(self):
+                pass
+
+            @context.xexample(".and_assert_*")
+            async def and_assert(self):
+                pass
+                # .and_assert_called_exactly(times)
+                # .and_assert_called_once()
+                # .and_assert_called_twice()
+                # .and_assert_called_at_least(times)
+                # .and_assert_called_at_most(times)
+                # .and_assert_called()
+                # .and_assert_called_ordered()
+                # .and_assert_not_called()
+
+        @context.shared_context
+        def sync_methods_examples(context):
+            @context.sub_context
+            def and_callable_is_a_sync_instance_method(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "async_instance_method"
+
+                context.merge_context("mock async callable with sync exapmles")
+
+            @context.sub_context
+            def and_callable_is_a_sync_class_method(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "async_class_method"
+
+                context.merge_context("mock async callable with sync exapmles")
+
+            @context.sub_context
+            def and_callable_is_a_sync_static_method(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "async_static_method"
+
+                context.merge_context("mock async callable with sync exapmles")
+
+            @context.sub_context
+            def and_callable_is_a_sync_magic_method(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "__aiter__"
+
+                context.merge_context("mock async callable with sync exapmles")
+
+        ##
+        ## Contexts
+        ##
+
+        @context.sub_context
+        def when_target_is_a_module(context):
+            @context.memoize_before
+            async def target_arg(self):
+                return "tests.sample_module"
+
+            @context.memoize_before
+            async def real_target(self):
+                return sample_module
+
+            @context.sub_context
+            def and_callable_is_a_function(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "async_test_function"
+
+                context.merge_context("mock async callable with sync exapmles")
+
+            @context.sub_context
+            def and_callable_is_an_async_function(context):
+                @context.before
+                def before(self):
+                    self.callable_arg = "async_test_function"
+                    self.original_callable = getattr(
+                        self.real_target, self.callable_arg
+                    )
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
+
+                context.merge_context("mock configuration examples")
+
+        @context.sub_context
+        def when_target_is_a_class(context):
+            @context.before
+            async def before(self):
+                self.real_target = Target
+                self.target_arg = Target
+
+            context.merge_context("sync methods examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_instance_method(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "async_instance_method"
+
+                @context.xexample
+                async def it_is_not_allowed(self):
+                    with self.assertRaises(ValueError):
+                        mock_async_callable(Target, self.callable_arg)
+
+            @context.sub_context
+            def and_callable_is_an_async_class_method(context):
+                @context.before
+                async def before(self):
+                    self.original_callable = Target.class_method
+                    self.callable_arg = "async_class_method"
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = Target.class_method
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_static_method(context):
+                @context.before
+                async def before(self):
+                    self.original_callable = Target.static_method
+                    self.callable_arg = "async_static_method"
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = Target.static_method
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_magic_method(context):
+                @context.xexample
+                async def it_is_not_allowed(self):
+                    with self.assertRaises(ValueError):
+                        mock_async_callable(Target, "__aiter__")
+
+        @context.sub_context
+        def an_instance(context):
+            @context.before
+            async def before(self):
+                target = Target()
+                self.real_target = target
+                self.target_arg = target
+
+            context.merge_context("sync methods examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_instance_method(context):
+                @context.memoize_before
+                async def callable_arg(self):
+                    return "async_instance_method"
+
+                @context.before
+                async def before(self):
+                    self.original_callable = getattr(
+                        self.real_target, self.callable_arg
+                    )
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_class_method(context):
+                @context.before
+                async def before(self):
+                    self.callable_arg = "async_class_method"
+                    self.original_callable = getattr(
+                        self.real_target, self.callable_arg
+                    )
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_static_method(context):
+                @context.before
+                async def before(self):
+                    self.callable_arg = "async_static_method"
+                    self.original_callable = getattr(
+                        self.real_target, self.callable_arg
+                    )
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
+
+                context.merge_context("mock configuration examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_magic_method(context):
+                context.memoize_before("call_args", lambda _: ())
+                context.memoize_before("call_kwargs", lambda _: {})
+
+                @context.before
+                async def before(self):
+                    self.callable_arg = "__aiter__"
+                    self.real_target = self.target
+                    self.target_arg = self.real_target
+                    self.original_callable = getattr(
+                        self.real_target, self.callable_arg
+                    )
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = lambda: aiter(self.target)
+
+                context.merge_context(
+                    "mock configuration examples",
+                    callable_accepts_no_args=True,
+                    can_yield=False,
                 )
 
         @context.sub_context
-        def and_callable_is_a_class_method(context):
+        def when_target_is_a_StrictMock(context):
             @context.before
             def before(self):
-                self.callable_arg = "class_method"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
+                target = StrictMock(template=Target)
+                self.original_callable = None
+                self.real_target = target
+                self.target_arg = target
+
+            context.merge_context("sync methods examples")
+
+            @context.sub_context
+            def and_callable_is_an_async_instance_method(context):
+                context.memoize_before(
+                    "callable_arg", lambda _: "async_instance_method"
                 )
-                self.callable_target = self.real_target.class_method
 
-            context.merge_context("examples for target", has_original_callable=False)
-            context.merge_context("other instances are not mocked")
-            context.merge_context("class is not mocked")
+                @context.before
+                async def before(self):
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
 
-        @context.sub_context
-        def and_callable_is_a_static_method(context):
-            @context.before
-            def before(self):
-                self.callable_arg = "static_method"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
+                context.merge_context(
+                    "mock configuration examples", has_original_callable=False
                 )
-                self.callable_target = self.real_target.static_method
 
-            context.merge_context("examples for target", has_original_callable=False)
-            context.merge_context("other instances are not mocked")
-            context.merge_context("class is not mocked")
+            @context.sub_context
+            def and_callable_is_an_async_class_method(context):
+                @context.before
+                async def before(self):
+                    self.callable_arg = "async_class_method"
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
 
-        @context.sub_context
-        def and_callable_is_a_magic_method(context):
-            context.memoize("call_args", lambda _: ())
-            context.memoize("call_kwargs", lambda _: {})
-
-            @context.before
-            def before(self):
-                self.callable_arg = "__str__"
-                self.mock_callable_dsl = mock_callable(
-                    self.target_arg, self.callable_arg
+                context.merge_context(
+                    "mock configuration examples", has_original_callable=False
                 )
-                self.callable_target = lambda: str(self.real_target)
 
-            context.merge_context(
-                "examples for target",
-                callable_accepts_no_args=True,
-                has_original_callable=False,
-                can_yield=False,
-            )
-            context.merge_context("other instances are not mocked")
+            @context.sub_context
+            def and_callable_is_a_async_static_method(context):
+                @context.before
+                def before(self):
+                    self.callable_arg = "async_static_method"
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = getattr(self.real_target, self.callable_arg)
+
+                context.merge_context(
+                    "mock configuration examples", has_original_callable=False
+                )
+
+            @context.sub_context
+            def and_callable_is_an_async_magic_method(context):
+                context.memoize_before("call_args", lambda _: ())
+                context.memoize_before("call_kwargs", lambda _: {})
+
+                @context.before
+                async def before(self):
+                    self.callable_arg = "__aiter__"
+                    self.mock_callable_dsl = mock_async_callable(
+                        self.target_arg, self.callable_arg
+                    )
+                    self.callable_target = lambda: aiter(self.real_target)
+
+                context.merge_context(
+                    "mock configuration examples",
+                    callable_accepts_no_args=True,
+                    has_original_callable=False,
+                    can_yield=False,
+                )

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -7,6 +7,7 @@ import testslide
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 
 from testslide.mock_callable import (
+    mock_async_callable,
     mock_callable,
     UndefinedBehaviorForCall,
     UnexpectedCallReceived,
@@ -1354,7 +1355,11 @@ def callable_mocks(context):
         def mock_async_callable_with_sync_exapmles(context):
             @context.xexample
             async def can_not_mock(self):
-                pass
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "mock_async_callable\(\) can not be used with non coroutine functions\.",
+                ):
+                    mock_async_callable(self.target_arg, self.callable_arg)
 
             @context.xexample
             async def can_mock_with_flag(self):
@@ -1466,12 +1471,12 @@ def callable_mocks(context):
             @context.sub_context
             def and_callable_is_an_async_function(context):
                 @context.before
-                def before(self):
+                async def before(self):
                     self.callable_arg = "async_test_function"
                     self.original_callable = getattr(
                         self.real_target, self.callable_arg
                     )
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1504,7 +1509,7 @@ def callable_mocks(context):
                 async def before(self):
                     self.original_callable = Target.class_method
                     self.callable_arg = "async_class_method"
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = Target.class_method
@@ -1517,7 +1522,7 @@ def callable_mocks(context):
                 async def before(self):
                     self.original_callable = Target.static_method
                     self.callable_arg = "async_static_method"
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = Target.static_method
@@ -1552,7 +1557,7 @@ def callable_mocks(context):
                     self.original_callable = getattr(
                         self.real_target, self.callable_arg
                     )
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1567,7 +1572,7 @@ def callable_mocks(context):
                     self.original_callable = getattr(
                         self.real_target, self.callable_arg
                     )
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1582,7 +1587,7 @@ def callable_mocks(context):
                     self.original_callable = getattr(
                         self.real_target, self.callable_arg
                     )
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1602,10 +1607,11 @@ def callable_mocks(context):
                     self.original_callable = getattr(
                         self.real_target, self.callable_arg
                     )
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
-                    self.callable_target = lambda: aiter(self.target)
+                    raise NotImplementedError
+                    # self.callable_target = lambda: aiter(self.target)
 
                 context.merge_context(
                     "mock configuration examples",
@@ -1632,7 +1638,7 @@ def callable_mocks(context):
 
                 @context.before
                 async def before(self):
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1646,7 +1652,7 @@ def callable_mocks(context):
                 @context.before
                 async def before(self):
                     self.callable_arg = "async_class_method"
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1660,7 +1666,7 @@ def callable_mocks(context):
                 @context.before
                 def before(self):
                     self.callable_arg = "async_static_method"
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
                     self.callable_target = getattr(self.real_target, self.callable_arg)
@@ -1677,10 +1683,11 @@ def callable_mocks(context):
                 @context.before
                 async def before(self):
                     self.callable_arg = "__aiter__"
-                    self.mock_callable_dsl = mock_async_callable(
+                    self.mock_async_callable_dsl = mock_async_callable(
                         self.target_arg, self.callable_arg
                     )
-                    self.callable_target = lambda: aiter(self.real_target)
+                    raise NotImplementedError
+                    # self.callable_target = lambda: aiter(self.real_target)
 
                 context.merge_context(
                     "mock configuration examples",

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -1345,7 +1345,7 @@ def mock_async_callable_tests(context):
     ##
 
     @context.shared_context
-    def mock_async_callable_with_sync_exapmles(context):
+    def mock_async_callable_with_sync_exapmles(context, can_mock_with_flag=True):
         @context.example
         async def can_not_mock(self):
             with self.assertRaisesRegex(
@@ -1358,9 +1358,13 @@ def mock_async_callable_tests(context):
             ):
                 mock_async_callable(self.target_arg, self.callable_arg)
 
-        @context.xexample
-        async def can_mock_with_flag(self):
-            pass
+        if can_mock_with_flag:
+
+            @context.example
+            async def can_mock_with_flag(self):
+                mock_async_callable(
+                    self.target_arg, self.callable_arg, callable_returns_coroutine=True
+                )
 
     @context.shared_context
     def mock_configuration_examples(
@@ -1423,7 +1427,11 @@ def mock_async_callable_tests(context):
                 async def exception_regex_message(self):
                     return "Patching an instance method at the class is not supported"
 
-            context.merge_context("mock async callable with sync exapmles")
+                context.merge_context(
+                    "mock async callable with sync exapmles", can_mock_with_flag=False
+                )
+            else:
+                context.merge_context("mock async callable with sync exapmles")
 
         @context.sub_context
         def and_callable_is_a_sync_class_method(context):
@@ -1453,7 +1461,11 @@ def mock_async_callable_tests(context):
                 async def exception_regex_message(self):
                     return "Patching an instance method at the class is not supported"
 
-            context.merge_context("mock async callable with sync exapmles")
+                context.merge_context(
+                    "mock async callable with sync exapmles", can_mock_with_flag=False
+                )
+            else:
+                context.merge_context("mock async callable with sync exapmles")
 
     ##
     ## Contexts

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -1,0 +1,8 @@
+def test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+    "This function is used by some unit tests only"
+    return "original response"
+
+
+async def async_test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+    "This function is used by some unit tests only"
+    return "original response"

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -280,8 +280,10 @@ class _ExampleRunner:
             warning_class = type(message)
             pattern = failure_warning_messages.get(warning_class, None)
             if pattern and re.compile(pattern).match(str(message)):
+                print("Caught!")
                 caught_failures.append(message)
             else:
+                print("Original")
                 original_showwarning(message, category, filename, lineno, file, line)
 
         warnings.showwarning = showwarning

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -280,13 +280,22 @@ class _ExampleRunner:
             warning_class = type(message)
             pattern = failure_warning_messages.get(warning_class, None)
             if pattern and re.compile(pattern).match(str(message)):
-                print("Caught!")
                 caught_failures.append(message)
             else:
-                print("Original")
                 original_showwarning(message, category, filename, lineno, file, line)
 
         warnings.showwarning = showwarning
+
+        original_logger_warning = asyncio.log.logger.warning
+
+        def logger_warning(msg, *args, **kwargs):
+            if re.compile("^Executing .+ took .+ seconds$").match(str(msg)):
+                caught_failures.append(RuntimeError(msg % args))
+            else:
+                original_logger_warning(msg, *args, **kwargs)
+
+        asyncio.log.logger.warning = logger_warning
+
         aggregated_exceptions = AggregatedExceptions()
 
         try:
@@ -294,6 +303,7 @@ class _ExampleRunner:
                 yield
         finally:
             warnings.showwarning = original_showwarning
+            asyncio.log.logger.warning = original_logger_warning
             for failure in caught_failures:
                 with aggregated_exceptions.catch():
                     raise failure

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -808,8 +808,3 @@ class TestCase(unittest.TestCase):
     @staticmethod
     def mock_constructor(target, class_name):
         return testslide.mock_constructor.mock_constructor(target, class_name)
-
-
-def _test_function(arg1, arg2, kwarg1=None, kwarg2=None):
-    "This function is used by some unit tests only"
-    return "original response"

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -122,6 +122,14 @@ class UnexpectedCallArguments(BaseException):
     """
 
 
+class NotACoroutine(BaseException):
+    """
+    Raised when a mock that requires a coroutine is not mocked with one.
+
+    Inherits from BaseException to avoid being caught by tested code.
+    """
+
+
 ##
 ## Runners
 ##
@@ -391,7 +399,13 @@ class _AsyncImplementationRunner(_AsyncRunner):
 
     async def run(self, *args, **kwargs):
         await super().run(*args, **kwargs)
-        return await self.new_implementation(*args, **kwargs)
+        coro = self.new_implementation(*args, **kwargs)
+        if not inspect.iscoroutine(coro):
+            raise NotACoroutine(
+                f"Function did not return a coroutine.\n"
+                f"{self.new_implementation} must return a coroutine."
+            )
+        return await coro
 
 
 class _CallOriginalRunner(_Runner):

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
 import inspect
 import functools
 from typing import List, Callable  # noqa
@@ -91,6 +92,11 @@ def _format_args(indent, *args, **kwargs):
             s += "{}".format(indentation)
         s += "}\n"
     return s
+
+
+def _is_coroutine(obj):
+
+    return inspect.iscoroutine(obj) or isinstance(obj, asyncio.coroutines.CoroWrapper)
 
 
 ##
@@ -400,7 +406,7 @@ class _AsyncImplementationRunner(_AsyncRunner):
     async def run(self, *args, **kwargs):
         await super().run(*args, **kwargs)
         coro = self.new_implementation(*args, **kwargs)
-        if not inspect.iscoroutine(coro):
+        if not _is_coroutine(coro):
             raise NotACoroutine(
                 f"Function did not return a coroutine.\n"
                 f"{self.new_implementation} must return a coroutine."
@@ -1004,7 +1010,7 @@ class _MockAsyncCallableDSL(_MockCallableDSL):
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
             coro = func(self._original_callable, *args, **kwargs)
-            if not inspect.iscoroutine(coro):
+            if not _is_coroutine(coro):
                 raise NotACoroutine(
                     f"Function did not return a coroutine.\n"
                     f"{func} must return a coroutine."

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -490,7 +490,7 @@ def _patch(target, method, new_value):
         target = testslide._importer(target)
 
     if isinstance(target, StrictMock):
-        template_value = getattr(target.__template, method, None)
+        template_value = getattr(target._template, method, None)
         if (
             template_value
             and callable(template_value)

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -490,6 +490,18 @@ def _patch(target, method, new_value):
         target = testslide._importer(target)
 
     if isinstance(target, StrictMock):
+        template_value = getattr(target.__template, method, None)
+        if (
+            template_value
+            and callable(template_value)
+            and inspect.iscoroutinefunction(template_value)
+        ):
+            raise ValueError(
+                "mock_callable() can not be used with coroutine functions.\n"
+                f"The attribute '{method}' of the template class of {target} "
+                "is a coroutine function. You can use mock_async_callable() "
+                "instead."
+            )
         original_callable = None
     else:
         original_callable = getattr(target, method)
@@ -504,6 +516,12 @@ def _patch(target, method, new_value):
                 "mock_callable() can not be used with with classes: {}. Perhaps you want to use mock_constructor() instead.".format(
                     repr(original_callable)
                 )
+            )
+        if inspect.iscoroutinefunction(original_callable):
+            raise ValueError(
+                "mock_callable() can not be used with coroutine functions.\n"
+                f"{original_callable} is a coroutine function. You can use "
+                "mock_async_callable() instead."
             )
 
     if not isinstance(target, StrictMock):

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -14,8 +14,8 @@ from unittest.mock import _must_skip
 
 def _add_signature_validation(value, template, attr_name):
     if isinstance(template, StrictMock):
-        if "__template" in template.__dict__:
-            template = template.__template
+        if "_template" in template.__dict__:
+            template = template._template
         else:
             return value
 
@@ -334,9 +334,9 @@ class StrictMock(object):
         on the object's class __dict__.
         https://github.com/facebookincubator/TestSlide/issues/23
         """
-        if not self.__template:
+        if not self._template:
             return
-        for klass in self.__template.mro():
+        for klass in self._template.mro():
             if klass is object:
                 continue
             for name in klass.__dict__:
@@ -349,14 +349,14 @@ class StrictMock(object):
                     setattr(self, name, _DefaultMagic(self, name))
 
     def _setup_default_context_manager(self, default_context_manager):
-        if self.__template and default_context_manager:
-            if hasattr(self.__template, "__enter__") and hasattr(
-                self.__template, "__exit__"
+        if self._template and default_context_manager:
+            if hasattr(self._template, "__enter__") and hasattr(
+                self._template, "__exit__"
             ):
                 self.__enter__ = lambda: self
                 self.__exit__ = lambda exc_type, exc_value, traceback: None
-            if hasattr(self.__template, "__aenter__") and hasattr(
-                self.__template, "__aexit__"
+            if hasattr(self._template, "__aenter__") and hasattr(
+                self._template, "__aexit__"
             ):
 
                 async def aenter():
@@ -383,10 +383,10 @@ class StrictMock(object):
         """
         if template and not inspect.isclass(template):
             raise ValueError("Template must be a class.")
-        self.__dict__["__template"] = template
+        self.__dict__["_template"] = template
 
-        self.__dict__["__runtime_attrs"] = runtime_attrs or []
-        self.__dict__["__name"] = name
+        self.__dict__["_runtime_attrs"] = runtime_attrs or []
+        self.__dict__["_name"] = name
 
         frameinfo = inspect.getframeinfo(inspect.stack()[1][0])
         filename = frameinfo.filename
@@ -406,24 +406,22 @@ class StrictMock(object):
 
     @property
     def __class__(self):
-        return self.__template if self.__template is not None else type(self)
+        return self._template if self._template is not None else type(self)
 
     @property
-    def __template(self):
+    def _template(self):
         import testslide.mock_constructor  # Avoid cyclic dependencies
 
         # If the template class was mocked with mock_constructor(), this will
         # return the mocked subclass, which contains all attributes we need for
         # introspection.
-        return testslide.mock_constructor._get_class_or_mock(
-            self.__dict__["__template"]
-        )
+        return testslide.mock_constructor._get_class_or_mock(self.__dict__["_template"])
 
     @property
-    def __runtime_attrs(self):
-        return self.__dict__["__runtime_attrs"]
+    def _runtime_attrs(self):
+        return self.__dict__["_runtime_attrs"]
 
-    def __template_has_attr(self, name):
+    def _template_has_attr(self, name):
         def get_class_init(klass):
             import testslide.mock_constructor  # Avoid cyclic dependencies
 
@@ -440,8 +438,8 @@ class StrictMock(object):
                 return klass.__init__
 
         def is_runtime_attr():
-            if self.__template:
-                for klass in self.__template.mro():
+            if self._template:
+                for klass in self._template.mro():
                     template_init = get_class_init(klass)
                     if not inspect.isfunction(template_init):
                         continue
@@ -454,9 +452,9 @@ class StrictMock(object):
             return False
 
         return (
-            hasattr(self.__template, name)
-            or name in self.__runtime_attrs
-            or name in getattr(self.__template, "__slots__", [])
+            hasattr(self._template, name)
+            or name in self._runtime_attrs
+            or name in getattr(self._template, "__slots__", [])
             or is_runtime_attr()
         )
 
@@ -475,17 +473,17 @@ class StrictMock(object):
                 )
 
         mock_value = value
-        if self.__template:
-            if not self.__template_has_attr(name):
+        if self._template:
+            if not self._template_has_attr(name):
                 raise NonExistentAttribute(self, name)
 
-            if hasattr(self.__template, name):
-                template_value = getattr(self.__template, name)
+            if hasattr(self._template, name):
+                template_value = getattr(self._template, name)
                 if callable(template_value):
                     if not callable(value):
                         raise NonCallableValue(self, name)
                     value_with_sig_val = _add_signature_validation(
-                        value, self.__template, name
+                        value, self._template, name
                     )
                     if inspect.iscoroutinefunction(template_value):
 
@@ -505,7 +503,7 @@ class StrictMock(object):
         setattr(type(self), name, mock_value)
 
     def __getattr__(self, name):
-        if self.__template and self.__template_has_attr(name):
+        if self._template and self._template_has_attr(name):
             raise UndefinedAttribute(self, name)
         else:
             raise AttributeError(f"'{name}' was not set for {self}.")
@@ -516,15 +514,13 @@ class StrictMock(object):
 
     def __repr__(self):
         template_str = (
-            " template={}.{}".format(
-                self.__template.__module__, self.__template.__name__
-            )
-            if self.__template
+            " template={}.{}".format(self._template.__module__, self._template.__name__)
+            if self._template
             else ""
         )
 
-        if self.__dict__["__name"]:
-            name_str = " name={}".format(repr(self.__dict__["__name"]))
+        if self.__dict__["_name"]:
+            name_str = " name={}".format(repr(self.__dict__["_name"]))
         else:
             name_str = ""
 
@@ -540,7 +536,7 @@ class StrictMock(object):
     def __str__(self):
         return self.__repr__()
 
-    def __get_copyable_attrs(self, self_copy):
+    def _get_copyable_attrs(self, self_copy):
         attrs = []
         for name in type(self).__dict__:
             if name not in self_copy.__dict__:
@@ -555,10 +551,10 @@ class StrictMock(object):
 
     def __copy__(self):
         self_copy = type(self)(
-            template=self.__template, runtime_attrs=self.__runtime_attrs
+            template=self._template, runtime_attrs=self._runtime_attrs
         )
 
-        for name in self.__get_copyable_attrs(self_copy):
+        for name in self._get_copyable_attrs(self_copy):
             setattr(self_copy, name, type(self).__dict__[name])
 
         return self_copy
@@ -567,10 +563,10 @@ class StrictMock(object):
         if memo is None:
             memo = {}
         self_copy = type(self)(
-            template=self.__template, runtime_attrs=self.__runtime_attrs
+            template=self._template, runtime_attrs=self._runtime_attrs
         )
         memo[id(self)] = self_copy
 
-        for name in self.__get_copyable_attrs(self_copy):
+        for name in self._get_copyable_attrs(self_copy):
             setattr(self_copy, name, copy.deepcopy(type(self).__dict__[name], memo))
         return self_copy


### PR DESCRIPTION
Implement `mock_async_callable()`. There's plenty of checks / tests against corner case scenarios (eg: using it for a non coroutine function). The interface follows the same model as `mock_callable()`, with minor differences that are documented.

Beware when merging as this branch is stacked over `fail_mock_callable_with_async`.

Closes #19 .