### PR TITLE
Fix StrictMock copy/deepcopy

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -622,22 +622,30 @@ def strict_mock(context):
             @context.before
             def set_attributes(self):
                 self.strict_mock.attr = self.attr
+                self.strict_mock.instance_method = lambda arg: "mock"
 
             @context.example("copy.copy()")
             def copy_copy(self):
                 strict_mock_copy = copy.copy(self.strict_mock)
-                self.assertEqual(self.strict_mock.attr, strict_mock_copy.attr)
-                # it is a shallow copy
-                strict_mock_copy.attr[self.key] = None
-                self.assertEqual(self.strict_mock.attr, strict_mock_copy.attr)
+                self.assertEqual(id(self.strict_mock.attr), id(strict_mock_copy.attr))
+                self.assertEqual(
+                    id(self.strict_mock.instance_method),
+                    id(strict_mock_copy.instance_method),
+                )
 
             @context.example("copy.deepcopy()")
             def copy_deepcopy(self):
                 strict_mock_copy = copy.deepcopy(self.strict_mock)
                 self.assertEqual(self.strict_mock.attr, strict_mock_copy.attr)
-                # it is a deep copy
-                strict_mock_copy.attr[self.key] = None
-                self.assertNotEqual(self.strict_mock.attr, strict_mock_copy.attr)
+                self.assertNotEqual(
+                    id(self.strict_mock.attr), id(strict_mock_copy.attr)
+                )
+                self.assertEqual((self.strict_mock.attr), (strict_mock_copy.attr))
+                self.assertNotEqual(
+                    id(self.strict_mock.instance_method),
+                    id(strict_mock_copy.instance_method),
+                )
+                self.assertEqual(self.strict_mock.instance_method(1), "mock")
 
     @context.sub_context
     def with_trim_path_prefix(context):

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -176,6 +176,21 @@ class _MethodProxy(object):
     def __call__(self, *args, **kwargs):
         return self.__dict__["_mock_value"](*args, **kwargs)
 
+    def __copy__(self):
+        return type(self)(
+            mock_value=self.__dict__["_mock_value"], value=self.__dict__["_value"]
+        )
+
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+            memo = {}
+        self_copy = type(self)(
+            mock_value=copy.deepcopy(self.__dict__["_mock_value"]),
+            value=copy.deepcopy(self.__dict__["_value"]),
+        )
+        memo[id(self)] = self_copy
+        return self_copy
+
 
 class StrictMock(object):
     """
@@ -583,7 +598,7 @@ class StrictMock(object):
         )
 
         for name in self._get_copyable_attrs(self_copy):
-            setattr(self_copy, name, type(self).__dict__[name])
+            setattr(type(self_copy), name, type(self).__dict__[name])
 
         return self_copy
 
@@ -596,5 +611,7 @@ class StrictMock(object):
         memo[id(self)] = self_copy
 
         for name in self._get_copyable_attrs(self_copy):
-            setattr(self_copy, name, copy.deepcopy(type(self).__dict__[name], memo))
+            setattr(
+                type(self_copy), name, copy.deepcopy(type(self).__dict__[name], memo)
+            )
         return self_copy


### PR DESCRIPTION
Fix deepcopy when we had callable attributes mocked, which under the hood, are set to _MethodProxy.