### PR TITLE
Remove colon from first line of exception

### DIFF
--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -165,7 +165,7 @@ class AggregatedExceptions(Exception):
             self.append_exception(exception)
 
     def __str__(self):
-        return "{} failures:\n".format(len(self.exceptions)) + "\n".join(
+        return "{} failures.\n".format(len(self.exceptions)) + "\n".join(
             f"{type(e)}: {str(e)}" for e in self.exceptions
         )
 


### PR DESCRIPTION
First line of exception strings should be self contained: swapping ":" for "." at the end of the line does that.