### PR TITLE
Fix callable runtime_attr

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -283,9 +283,11 @@ def strict_mock(context):
 
                 @context.example
                 def allows_init_set_attributes_to_be_set(self):
-                    new_value = "new value"
+                    new_value = lambda msg: f"hello {msg}"
                     self.strict_mock.runtime_attr_from_init = new_value
-                    self.assertEqual(self.strict_mock.runtime_attr_from_init, new_value)
+                    self.assertEqual(
+                        self.strict_mock.runtime_attr_from_init("world"), "hello world"
+                    )
 
                 @context.example
                 def allows_parent_init_set_attributes_to_be_set(self):

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -564,12 +564,12 @@ class StrictMock(object):
                         mock_value = _MethodProxy(value_with_sig_val, value)
             else:
                 if callable(value):
-                    # We don't really need the proxy here, but it server the
+                    # We don't really need the proxy here, but it serves the
                     # double purpose of swallowing self / cls when needed.
                     mock_value = _MethodProxy(value, value)
         else:
             if callable(value):
-                # We don't really need the proxy here, but it server the
+                # We don't really need the proxy here, but it serves the
                 # double purpose of swallowing self / cls when needed.
                 mock_value = _MethodProxy(value, value)
 

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -562,6 +562,11 @@ class StrictMock(object):
                         mock_value = _MethodProxy(validate_awaitable_return, value)
                     else:
                         mock_value = _MethodProxy(value_with_sig_val, value)
+            else:
+                if callable(value):
+                    # We don't really need the proxy here, but it server the
+                    # double purpose of swallowing self / cls when needed.
+                    mock_value = _MethodProxy(value, value)
         else:
             if callable(value):
                 # We don't really need the proxy here, but it server the


### PR DESCRIPTION
Fix "self" not being swallowed when mocking callable runtime attributes.