### PR TITLE
Add a flag to disable signature validation

### DIFF
--- a/docs/strict_mock/index.rst
+++ b/docs/strict_mock/index.rst
@@ -185,6 +185,33 @@ The mock itself is yielded.
 
   This also works for `asynchronous context managers <https://docs.python.org/3/reference/datamodel.html#asynchronous-context-managers>`_.
 
+Disabling Signature Validation
+""""""""""""""""""""""""""""""
+By default, ``StrictMock`` will validate arguments passed to callable attributes - it does this by inserting a proxy object in between the attribute and the value. In some rare situations, this proxy object can cause issues (eg if you ``assert type(self.attr) == Foo``). If having ``type()`` return the correct value is more important than having signatures validated, you can disable signature validation:
+
+.. code-block:: ipython
+
+  In [1]: from testslide import StrictMock
+
+  In [2]: class CallableObject(object):
+     ...:   def __call__(self):
+     ...:     pass
+     ...:
+
+  In [3]: s = StrictMock()
+
+  In [4]: s.attr = CallableObject()
+
+  In [5]: type(s.attr)
+  Out[5]: testslide.strict_mock._MethodProxy
+
+  In [6]: s = StrictMock(signature_validation=False)
+
+  In [7]: s.attr = CallableObject()
+
+  In [8]: type(s.attr)
+  Out[8]: __main__.CallableObject
+
 Setting Attributes
 ^^^^^^^^^^^^^^^^^^
 

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -130,11 +130,6 @@ class CallableObject(object):
         pass
 
 
-class ObjectWithCallableAttribute(object):
-    def __init__(self):
-        self.attr = CallableObject()
-
-
 @context("StrictMock")  # noqa: C901
 def strict_mock(context):
     @context.function
@@ -889,16 +884,14 @@ def strict_mock(context):
         def callable_attribute_replaced_with_proxy(self):
             # Callable attributes normally get replaced with `_MethodProxy`
             # instances, but type() can still tell the difference
-            real_obj = ObjectWithCallableAttribute()
             mock_obj = StrictMock()
-            mock_obj.attr = real_obj.attr
-            self.assertNotEqual(type(mock_obj.attr), type(real_obj.attr))
+            mock_obj.attr = CallableObject()
+            self.assertNotEqual(type(mock_obj.attr), type(CallableObject()))
 
         @context.example
         def callable_attribute_not_replaced_with_proxy(self):
             # If we want type() to give correct results, then we need
             # to disable method proxies
-            real_obj = ObjectWithCallableAttribute()
             mock_obj = StrictMock(signature_validation=False)
-            mock_obj.attr = real_obj.attr
-            self.assertEqual(type(mock_obj.attr), type(real_obj.attr))
+            mock_obj.attr = CallableObject()
+            self.assertEqual(type(mock_obj.attr), type(CallableObject()))

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -125,6 +125,16 @@ class ContextManagerTemplate(Template):
         pass
 
 
+class CallableObject(object):
+    def __call__(self):
+        pass
+
+
+class ObjectWithCallableAttribute(object):
+    def __init__(self):
+        self.attr = CallableObject()
+
+
 @context("StrictMock")  # noqa: C901
 def strict_mock(context):
     @context.function
@@ -873,32 +883,22 @@ def strict_mock(context):
                     async with self.strict_mock as m:
                         assert id(self.strict_mock) == id(m)
 
-    @context.memoize
-    def obj_with_callable_attribute(self):
-        class CallableObject(object):
-            def __call__(self):
-                pass
+    @context.sub_context
+    def disabling_signature_validation(context):
+        @context.example
+        def callable_attribute_replaced_with_proxy(self):
+            # Callable attributes normally get replaced with `_MethodProxy`
+            # instances, but type() can still tell the difference
+            real_obj = ObjectWithCallableAttribute()
+            mock_obj = StrictMock()
+            mock_obj.attr = real_obj.attr
+            self.assertNotEqual(type(mock_obj.attr), type(real_obj.attr))
 
-        class ObjWithCallableAttribute(object):
-            def __init__(self):
-                self.attr = CallableObject()
-
-        return ObjWithCallableAttribute()
-
-    @context.example
-    def callable_attribute_replaced_with_proxy(self):
-        # Callable attributes normally get replaced with `_MethodProxy`
-        # instances, but type() can still tell the difference
-        real_obj = self.obj_with_callable_attribute
-        mock_obj = StrictMock()
-        mock_obj.attr = real_obj.attr
-        self.assertNotEqual(type(mock_obj.attr), type(real_obj.attr))
-
-    @context.example
-    def callable_attribute_not_replaced_with_proxy(self):
-        # If we want type() to give correct results, then we need
-        # to disable method proxies
-        real_obj = self.obj_with_callable_attribute
-        mock_obj = StrictMock(signature_validation=False)
-        mock_obj.attr = real_obj.attr
-        self.assertEqual(type(mock_obj.attr), type(real_obj.attr))
+        @context.example
+        def callable_attribute_not_replaced_with_proxy(self):
+            # If we want type() to give correct results, then we need
+            # to disable method proxies
+            real_obj = ObjectWithCallableAttribute()
+            mock_obj = StrictMock(signature_validation=False)
+            mock_obj.attr = real_obj.attr
+            self.assertEqual(type(mock_obj.attr), type(real_obj.attr))

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -364,7 +364,12 @@ class StrictMock(object):
     ]
 
     def __new__(
-        cls, template=None, runtime_attrs=None, name=None, default_context_manager=True, signature_validation=True
+        cls,
+        template=None,
+        runtime_attrs=None,
+        name=None,
+        default_context_manager=True,
+        signature_validation=True,
     ):
         """
         For every new instance of StrictMock we dynamically create a subclass of

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -364,7 +364,7 @@ class StrictMock(object):
     ]
 
     def __new__(
-        cls, template=None, runtime_attrs=None, name=None, default_context_manager=True
+        cls, template=None, runtime_attrs=None, name=None, default_context_manager=True, signature_validation=True
     ):
         """
         For every new instance of StrictMock we dynamically create a subclass of
@@ -436,6 +436,7 @@ class StrictMock(object):
         runtime_attrs=None,
         name=None,
         default_context_manager=False,
+        signature_validation=True,
     ):
         """
         template: Template class to be used as a template for the mock.
@@ -446,6 +447,9 @@ class StrictMock(object):
         default_context_manager: If the template class is a context manager,
         setup a mock for __enter__/__aenter__ that yields itself and an empty function
         for __exit__/__aexit__.
+        signature_validation: validate that called attributes are called with the
+        correct parameters. This involves inserting a proxy between the attribute
+        and the method, so set this flag to False if you can't handle a proxy.
         """
         if template and not inspect.isclass(template):
             raise ValueError("Template must be a class.")
@@ -453,6 +457,7 @@ class StrictMock(object):
 
         self.__dict__["_runtime_attrs"] = runtime_attrs or []
         self.__dict__["_name"] = name
+        self.__dict__["_signature_validation"] = signature_validation
 
         frameinfo = inspect.getframeinfo(inspect.stack()[1][0])
         filename = frameinfo.filename
@@ -545,7 +550,7 @@ class StrictMock(object):
 
             if hasattr(self._template, name):
                 template_value = getattr(self._template, name)
-                if callable(template_value):
+                if callable(template_value) and self.__dict__["_signature_validation"]:
                     if not callable(value):
                         raise NonCallableValue(self, name)
                     value_with_sig_val = _add_signature_validation(
@@ -563,12 +568,12 @@ class StrictMock(object):
                     else:
                         mock_value = _MethodProxy(value_with_sig_val, value)
             else:
-                if callable(value):
+                if callable(value) and self.__dict__["_signature_validation"]:
                     # We don't really need the proxy here, but it serves the
                     # double purpose of swallowing self / cls when needed.
                     mock_value = _MethodProxy(value, value)
         else:
-            if callable(value):
+            if callable(value) and self.__dict__["_signature_validation"]:
                 # We don't really need the proxy here, but it serves the
                 # double purpose of swallowing self / cls when needed.
                 mock_value = _MethodProxy(value, value)


### PR DESCRIPTION
For times when the signature-validating proxy object causes issues

In particular, one can see this with Thrift objects:

- Thrift-py3 objects are callable, because they are immutable, and use the `__call__` interface to return a modified version of themselves
- Thrift-py3 objects will call `type()` to validate the types of their attributes, and we can't fake our `type()`

So when one does:

```
p1 = Parent1(child=Child())
p2 = Parent2(child=p1.child)
```

if `Parent1` has been replaced with a `StrictMock()`, then `p1.child` will have been replaced with a `_MethodProxy(Child())`, and in `Parent2`'s constructor, `assert type(child) == Child` will fail.