### PR TITLE
Add SlowCallback error type

### DIFF
--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -120,7 +120,7 @@ Every called coroutine must be awaited. If they are not, it means their code nev
     Successful: 1
     Failed: 1
 
-Even Loop Lock Up
+Slow Callback
 ^^^^^^^^^^^^^^^^^
 
 Async code must do their work in small chunks, properly awaiting other functions when needed. If an async function does some CPU intensive task that takes a long time to compute, or if it calls a sync function that takes a long time to return, the entirety of the event loop will be locked up. This means that no other code can be executed until this bad async function returns.
@@ -142,12 +142,12 @@ If during the test execution a task blocks the event loop, it will trigger a tes
 
   $ testslide blocked_event_loop.py 
   Blocked event loop
-    blocking sleep: RuntimeError: Executing <Task finished coro=<_ExampleRunner._real_async_run_all_hooks_and_example() done, defined at /opt/python/lib/python3.7/site-packages/testslide/__init__.py:220> result=None created at /opt/python/lib/python3.7/asyncio/base_events.py:558> took 1.002 seconds
+    blocking sleep: SlowCallback: Executing <Task finished coro=<_ExampleRunner._real_async_run_all_hooks_and_example() done, defined at /opt/python/lib/python3.7/site-packages/testslide/__init__.py:220> result=None created at /opt/python/lib/python3.7/asyncio/base_events.py:558> took 1.002 seconds
 
   Failures:
 
     1) Blocked event loop: blocking sleep
-      1) RuntimeError: Executing <Task finished coro=<_ExampleRunner._real_async_run_all_hooks_and_example() done, defined at /opt/python/lib/python3.7/site-packages/testslide/__init__.py:220> result=None created at /opt/python/lib/python3.7/asyncio/base_events.py:558> took 1.002 seconds
+      1) SlowCallback: Executing <Task finished coro=<_ExampleRunner._real_async_run_all_hooks_and_example() done, defined at /opt/python/lib/python3.7/site-packages/testslide/__init__.py:220> result=None created at /opt/python/lib/python3.7/asyncio/base_events.py:558> took 1.002 seconds
         File "/opt/python/lib/python3.7/contextlib.py", line 119, in __exit__
           next(self.gen)
 

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -7,10 +7,11 @@ import sys
 import asyncio
 import unittest
 import time
+import re
 
 from unittest.mock import Mock, call, patch
 
-from testslide import Context, AggregatedExceptions, reset
+from testslide import Context, AggregatedExceptions, SlowCallback, reset
 from testslide.dsl import context, xcontext, fcontext
 import os
 import subprocess
@@ -1859,7 +1860,12 @@ class SmokeTestAsync(TestDSLBase):
                 async def example(self):
                     time.sleep(0.1)
 
-            with self.assertRaisesRegex(RuntimeError, "^Executing .+ took .+ seconds$"):
+            with self.assertRaisesRegex(
+                SlowCallback,
+                re.compile(
+                    r"^Executing .+ took .+ seconds\nSlow callback detected.*$", re.M
+                ),
+            ):
                 self.run_first_context_first_example()
 
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -207,6 +207,12 @@ class UnexpectedSuccess(Exception):
     """
 
 
+class SlowCallback(Exception):
+    """
+    Raised by TestSlide when an asyncio slow callback warning is detected
+    """
+
+
 class _ExampleRunner:
     def __init__(self, example):
         self.example = example
@@ -298,7 +304,8 @@ class _ExampleRunner:
 
         def logger_warning(msg, *args, **kwargs):
             if re.compile("^Executing .+ took .+ seconds$").match(str(msg)):
-                caught_failures.append(RuntimeError(msg % args))
+                msg = f"{msg}\nSlow callback detected, see https://github.com/facebookincubator/TestSlide/blob/master/docs/testslide_dsl/async_support/index.rst#slow-callback"
+                caught_failures.append(SlowCallback(msg % args))
             else:
                 original_logger_warning(msg, *args, **kwargs)
 


### PR DESCRIPTION
TestSlide previously raised a RuntimeError when it detected an asyncio
slow callback warning message, change that to a custom SlowCallback
exception type that makes the failure case easier to track down, since
the default message is fairly opaque if you haven't seen it before.

This could potentially be extended with more information to help track
down the offending function, but Python does not provide much
information, so in this PR I am just adding the exception class to at
least point in the right direction.