### PR TITLE
Amend small bits of doc

### DIFF
--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -121,7 +121,7 @@ Every called coroutine must be awaited. If they are not, it means their code nev
     Failed: 1
 
 Slow Callback
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 Async code must do their work in small chunks, properly awaiting other functions when needed. If an async function does some CPU intensive task that takes a long time to compute, or if it calls a sync function that takes a long time to return, the entirety of the event loop will be locked up. This means that no other code can be executed until this bad async function returns.
 
@@ -148,6 +148,9 @@ If during the test execution a task blocks the event loop, it will trigger a tes
 
     1) Blocked event loop: blocking sleep
       1) SlowCallback: Executing <Task finished coro=<_ExampleRunner._real_async_run_all_hooks_and_example() done, defined at /opt/python/lib/python3.7/site-packages/testslide/__init__.py:220> result=None created at /opt/python/lib/python3.7/asyncio/base_events.py:558> took 1.002 seconds
+        During the execution of the async test a slow callback that blocked the event loop was detected.
+        Tip: you can customize the detection threshold with:
+          asyncio.get_running_loop().slow_callback_duration = seconds
         File "/opt/python/lib/python3.7/contextlib.py", line 119, in __exit__
           next(self.gen)
 

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -7,7 +7,6 @@ import sys
 import asyncio
 import unittest
 import time
-import re
 
 from unittest.mock import Mock, call, patch
 
@@ -1860,12 +1859,7 @@ class SmokeTestAsync(TestDSLBase):
                 async def example(self):
                     time.sleep(0.1)
 
-            with self.assertRaisesRegex(
-                SlowCallback,
-                re.compile(
-                    r"^Executing .+ took .+ seconds\nSlow callback detected.*$", re.M
-                ),
-            ):
+            with self.assertRaisesRegex(SlowCallback, "^Executing .+ took .+ seconds"):
                 self.run_first_context_first_example()
 
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -304,7 +304,13 @@ class _ExampleRunner:
 
         def logger_warning(msg, *args, **kwargs):
             if re.compile("^Executing .+ took .+ seconds$").match(str(msg)):
-                msg = f"{msg}\nSlow callback detected, see https://github.com/facebookincubator/TestSlide/blob/master/docs/testslide_dsl/async_support/index.rst#slow-callback"
+                msg = (
+                    f"{msg}\n"
+                    "During the execution of the async test a slow callback "
+                    "that blocked the event loop was detected.\n"
+                    "Tip: you can customize the detection threshold with:\n"
+                    "  asyncio.get_running_loop().slow_callback_duration = seconds"
+                )
                 caught_failures.append(SlowCallback(msg % args))
             else:
                 original_logger_warning(msg, *args, **kwargs)


### PR DESCRIPTION
Documentation is provided here https://testslide.readthedocs.io/, let's not use links to GitHub sources directly.

I don't think there's an of the shelf way to get the current version so we can generate a link to https://testslide.readthedocs.io/en/2.0.1/testslide_dsl/async_support/index.html, so I added a short version of the doc in the exception message.