### PR TITLE
Disable async validation for builtins

### DIFF
--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -598,7 +598,7 @@ class _MockCallableDSL(object):
                 if (
                     coroutine_function
                     and (
-                        # FIXME We cant reliably introspect coroutine functions
+                        # FIXME We can not reliably introspect coroutine functions
                         # for builtins: https://bugs.python.org/issue38225
                         type(template_value) is not type(list.append)
                         and not inspect.iscoroutinefunction(template_value)
@@ -646,7 +646,7 @@ class _MockCallableDSL(object):
             if (
                 coroutine_function
                 and (
-                    # FIXME We cant reliably introspect coroutine functions
+                    # FIXME We can not reliably introspect coroutine functions
                     # for builtins: https://bugs.python.org/issue38225
                     type(original_callable) is not type(list.append)
                     and not inspect.iscoroutinefunction(original_callable)

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -597,7 +597,12 @@ class _MockCallableDSL(object):
                     )
                 if (
                     coroutine_function
-                    and not inspect.iscoroutinefunction(template_value)
+                    and (
+                        # FIXME We cant reliably introspect coroutine functions
+                        # for builtins: https://bugs.python.org/issue38225
+                        type(template_value) is not type(list.append)
+                        and not inspect.iscoroutinefunction(template_value)
+                    )
                     and not callable_returns_coroutine
                 ):
                     raise ValueError(
@@ -640,7 +645,12 @@ class _MockCallableDSL(object):
                 )
             if (
                 coroutine_function
-                and not inspect.iscoroutinefunction(original_callable)
+                and (
+                    # FIXME We cant reliably introspect coroutine functions
+                    # for builtins: https://bugs.python.org/issue38225
+                    type(original_callable) is not type(list.append)
+                    and not inspect.iscoroutinefunction(original_callable)
+                )
                 and not callable_returns_coroutine
             ):
                 raise ValueError(


### PR DESCRIPTION
As per [upstream Python bug](https://bugs.python.org/issue38225) and this [Cython bug](https://github.com/cython/cython/issues/2273), there's no reliable way to introspect if a callable is a coroutine function for builtins. There's a possibility that this gets fixed at Python 3.9 (by adding `__awaitable__` to coroutine functions), and later on Cython. Until then, let's disable checks for this use case, as it just does not work.