### PR TITLE
[strict_mock] Speed up first invocation

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -341,6 +341,19 @@ def strict_mock(context):
                     getattr(self.strict_mock, attr_name)
 
             @context.example
+            def shows_the_correct_file_and_linenum_when_raising_when_an_undefined_attribute_is_accessed(
+                self,
+            ):
+                attr_name = "non_callable"
+                with self.assertRaisesWithRegexMessage(
+                    UndefinedAttribute,
+                    f"'{attr_name}' is not set.\n"
+                    f"{self.strict_mock_rgx} must have a value set "
+                    "for this attribute if it is going to be accessed.",
+                ):
+                    getattr(self.strict_mock, attr_name)
+
+            @context.example
             def raises_when_an_non_existing_attribute_is_accessed(self):
                 attr_name = "non_existing_attr"
                 with self.assertRaisesWithRegexMessage(


### PR DESCRIPTION
This is done by getting only the minimum needed amount of frames from
the stack, and avoid retrieving the file contents for each when trying
to get the caller, when initializing the StrictMock object.

This avoids both, unnecessary file searches, and unnecessary file reads,
speeding up the first invocation from ~0.18s to ~0.00015 (only did a
couple tests, but the speed is up considerably).

Before:
```
test nothing
time for _get_caller: 0.17940688133239746
  make sure the first instance of strictmock does not timeout any tests: SlowCallback: ... took 0.180 seconds
```

After:
```
dummy test
time for _get_caller: 0.00014853477478027344
  make sure the first instance of strictmock does not timeout any tests
```