### PR TITLE
Add AnyWithCall matcher

### DIFF
--- a/docs/patching/argument_matchers/index.rst
+++ b/docs/patching/argument_matchers/index.rst
@@ -111,3 +111,11 @@ Generic
 	"``AnyTruthy()``", "Any object where ``bool(obj) == True``"
 	"``AnyFalsey()``", "Any object where ``bool(obj) == False``"
 	"``AnyInstanceOf()``", "Any object where ``isinstance(obj) == True``"
+	"``AnyWithCall(call)``", "Any object where ``call(obj) == True``"
+
+.. code-block:: python
+
+  self.mock_callable(os, 'remove')\
+    .for_call(AnyWithCall(lambda path: path.endswith("py"))\
+    .to_return_value(None)\
+    .and_assert_called_once()

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -132,6 +132,10 @@ class GenericTestCase(testslide.TestCase):
         self.assertEqual(testslide.matchers.AnyInstanceOf(str), "durrdurr")
         self.assertNotEqual(testslide.matchers.AnyInstanceOf(str), 7)
 
+    def testAnyWithCall(self):
+        self.assertEqual(testslide.matchers.AnyWithCall(lambda x: "b" in x), "abc")
+        self.assertNotEqual(testslide.matchers.AnyWithCall(lambda x: "d" in x), "abc")
+
 
 class StringTest(testslide.TestCase):
     def testAnyStr(self):

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import re
-from typing import List, Dict
+from typing import List, Dict, TypeVar
 
 
 class AlreadyChainedException(Exception):
@@ -398,3 +398,14 @@ class AnyFalsey(Matcher):
 class AnyInstanceOf(_RichComparison):
     def __init__(self, klass):
         super().__init__(klass=klass)
+
+
+T = TypeVar("T")
+
+
+class AnyWithCall(Matcher):
+    def __init__(self, call: Callable[[T], bool]) -> None:
+        self.call = call
+
+    def __eq__(self, other: T) -> bool:
+        return self.call(other)

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import re
-from typing import List, Dict, TypeVar
+from typing import Callable, Dict, List, TypeVar
 
 
 class AlreadyChainedException(Exception):


### PR DESCRIPTION
This creates a completely generic `Matcher` where you can pass a
function in to be called.  Something like

```
self.mock_callable(os, 'remove')\
  .for_call(AnyWithCall(lambda path: path.endswith("py"))\
  .to_return_value(None)\
  .and_assert_called_once()
```