### PR TITLE
[strict_mock] Support mocks in signature validation

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -511,38 +511,52 @@ def strict_mock(context):
                                         self.assertEqual(method("hello"), "mock: hello")
 
                                     @context.example
-                                    def works_with_Mock_parameter(self):
-                                        class Dummy_param:
+                                    def works_when_the_parameter_passed_is_an_instance_of_Mock(
+                                        self,
+                                    ):
+                                        class DummyParam:
                                             def get_string():
-                                                return "Dummy_param: not mocked"
+                                                return "DummyParam: not mocked"
 
                                         class Dummy:
-                                            def method(self, param: Dummy_param):
+                                            def method(self, param: DummyParam):
                                                 return f"Dummy: {param.get_string()}"
 
                                         my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = Mock(spec=Dummy_param)
+                                        my_mock = Mock(spec=DummyParam)
                                         my_mock.get_string.return_value = "mock_param"
 
-                                        my_strict_mock.method = lambda param: f"mock_method: {param.get_string()}"
-                                        self.assertEqual(my_strict_mock.method(param=my_mock), "mock_method: mock_param")
+                                        my_strict_mock.method = (
+                                            lambda param: f"mock_method: {param.get_string()}"
+                                        )
+                                        self.assertEqual(
+                                            my_strict_mock.method(param=my_mock),
+                                            "mock_method: mock_param",
+                                        )
 
                                     @context.example
-                                    def works_with_StrictMock_parameter(self):
-                                        class Dummy_param:
+                                    def works_when_the_parameter_passed_is_an_instance_of_StrictMock(
+                                        self,
+                                    ):
+                                        class DummyParam:
                                             def get_string():
-                                                return "Dummy_param: not mocked"
+                                                return "DummyParam: not mocked"
 
                                         class Dummy:
-                                            def method(self, param: Dummy_param):
+                                            def method(self, param: DummyParam):
                                                 return f"Dummy: {param.get_string()}"
 
                                         my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = StrictMock(template=Dummy_param)
+                                        my_mock = StrictMock(template=DummyParam)
                                         my_mock.get_string = lambda: "mock_param"
 
-                                        my_strict_mock.method = lambda param: f"mock_method: {param.get_string()}"
-                                        self.assertEqual(my_strict_mock.method(param=my_mock), "mock_method: mock_param")
+                                        my_strict_mock.method = (
+                                            lambda param: f"mock_method: {param.get_string()}"
+                                        )
+                                        self.assertEqual(
+                                            my_strict_mock.method(param=my_mock),
+                                            "mock_method: mock_param",
+                                        )
 
                             else:
 

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -18,6 +18,7 @@ import inspect
 import sys
 import re
 import os
+from unittest.mock import Mock
 
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 
@@ -508,6 +509,40 @@ def strict_mock(context):
                                             self.strict_mock, test_method_name
                                         )
                                         self.assertEqual(method("hello"), "mock: hello")
+
+                                    @context.example
+                                    def works_with_Mock_parameter(self):
+                                        class Dummy_param:
+                                            def get_string():
+                                                return "Dummy_param: not mocked"
+
+                                        class Dummy:
+                                            def method(self, param: Dummy_param):
+                                                return f"Dummy: {param.get_string()}"
+
+                                        my_strict_mock = StrictMock(template=Dummy)
+                                        my_mock = Mock(spec=Dummy_param)
+                                        my_mock.get_string.return_value = "mock_param"
+
+                                        my_strict_mock.method = lambda param: f"mock_method: {param.get_string()}"
+                                        self.assertEqual(my_strict_mock.method(param=my_mock), "mock_method: mock_param")
+
+                                    @context.example
+                                    def works_with_StrictMock_parameter(self):
+                                        class Dummy_param:
+                                            def get_string():
+                                                return "Dummy_param: not mocked"
+
+                                        class Dummy:
+                                            def method(self, param: Dummy_param):
+                                                return f"Dummy: {param.get_string()}"
+
+                                        my_strict_mock = StrictMock(template=Dummy)
+                                        my_mock = StrictMock(template=Dummy_param)
+                                        my_mock.get_string = lambda: "mock_param"
+
+                                        my_strict_mock.method = lambda param: f"mock_method: {param.get_string()}"
+                                        self.assertEqual(my_strict_mock.method(param=my_mock), "mock_method: mock_param")
 
                             else:
 

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -511,7 +511,7 @@ def strict_mock(context):
                                         self.assertEqual(method("hello"), "mock: hello")
 
                                     @context.example
-                                    def works_when_the_parameter_passed_is_an_instance_of_Mock(
+                                    def works_when_the_parameter_passed_is_an_instance_of_Mock_with_spec(
                                         self,
                                     ):
                                         class DummyParam:
@@ -535,7 +535,7 @@ def strict_mock(context):
                                         )
 
                                     @context.example
-                                    def works_when_the_parameter_passed_is_an_instance_of_StrictMock(
+                                    def works_when_the_parameter_passed_is_an_instance_of_StrictMock_with_template(
                                         self,
                                     ):
                                         class DummyParam:
@@ -548,6 +548,96 @@ def strict_mock(context):
 
                                         my_strict_mock = StrictMock(template=Dummy)
                                         my_mock = StrictMock(template=DummyParam)
+                                        my_mock.get_string = lambda: "mock_param"
+
+                                        my_strict_mock.method = (
+                                            lambda param: f"mock_method: {param.get_string()}"
+                                        )
+                                        self.assertEqual(
+                                            my_strict_mock.method(param=my_mock),
+                                            "mock_method: mock_param",
+                                        )
+
+                                    @context.example
+                                    def fails_when_the_parameter_passed_is_an_instance_of_Mock_with_wrong_spec(
+                                        self,
+                                    ):
+                                        class DummyParam:
+                                            def get_string():
+                                                return "DummyParam: not mocked"
+
+                                        class Dummy:
+                                            def method(self, param: DummyParam):
+                                                return f"Dummy: {param.get_string()}"
+
+                                        my_strict_mock = StrictMock(template=Dummy)
+                                        my_mock = Mock(spec=Template)
+
+                                        my_strict_mock.method = (
+                                            lambda param: f"mock_method: {param.get_string()}"
+                                        )
+                                        with self.assertRaises(TypeError):
+                                            my_strict_mock.method(param=my_mock)
+
+                                    @context.example
+                                    def fails_when_the_parameter_passed_is_an_instance_of_StrictMock_with_wrong_template(
+                                        self,
+                                    ):
+                                        class DummyParam:
+                                            def get_string():
+                                                return "DummyParam: not mocked"
+
+                                        class Dummy:
+                                            def method(self, param: DummyParam):
+                                                return f"Dummy: {param.get_string()}"
+
+                                        my_strict_mock = StrictMock(template=Dummy)
+                                        my_mock = StrictMock(template=Template)
+
+                                        my_strict_mock.method = (
+                                            lambda param: f"mock_method: {param.get_string()}"
+                                        )
+                                        with self.assertRaises(TypeError):
+                                            my_strict_mock.method(param=my_mock)
+
+                                    @context.example
+                                    def works_when_the_parameter_passed_is_an_instance_of_Mock_without_spec(
+                                        self,
+                                    ):
+                                        class DummyParam:
+                                            def get_string():
+                                                return "DummyParam: not mocked"
+
+                                        class Dummy:
+                                            def method(self, param: DummyParam):
+                                                return f"Dummy: {param.get_string()}"
+
+                                        my_strict_mock = StrictMock(template=Dummy)
+                                        my_mock = Mock()
+                                        my_mock.get_string.return_value = "mock_param"
+
+                                        my_strict_mock.method = (
+                                            lambda param: f"mock_method: {param.get_string()}"
+                                        )
+                                        self.assertEqual(
+                                            my_strict_mock.method(param=my_mock),
+                                            "mock_method: mock_param",
+                                        )
+
+                                    @context.example
+                                    def works_when_the_parameter_passed_is_an_instance_of_StrictMock_without_template(
+                                        self,
+                                    ):
+                                        class DummyParam:
+                                            def get_string():
+                                                return "DummyParam: not mocked"
+
+                                        class Dummy:
+                                            def method(self, param: DummyParam):
+                                                return f"Dummy: {param.get_string()}"
+
+                                        my_strict_mock = StrictMock(template=Dummy)
+                                        my_mock = StrictMock()
                                         my_mock.get_string = lambda: "mock_param"
 
                                         my_strict_mock.method = (

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -4,9 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import inspect
-import typeguard
-
 
 def _bail_if_private(candidate: str, allow_private: False):
     if (
@@ -20,26 +17,3 @@ def _bail_if_private(candidate: str, allow_private: False):
             "Please consider using patterns like dependency injection instead. "
             "If you really need to do this use the allow_private=True argument."
         )
-
-
-def _validate_function_signature(argspec: inspect.FullArgSpec, args, kwargs):
-    type_errs = []
-    for idx in range(0, len(args)):
-        if argspec.args:
-            arg = argspec.args[idx]
-            try:
-                __validate_argument_type(argspec.annotations, arg, args[idx])
-            except TypeError as te:
-                type_errs.append(te)
-    for k, v in kwargs.items():
-        try:
-            __validate_argument_type(argspec.annotations, k, v)
-        except TypeError as te:
-            type_errs.append(te)
-    return type_errs
-
-
-def __validate_argument_type(annotations, argname, value):
-    type_information = annotations.get(argname)
-    if type_information:
-        typeguard.check_type(argname, value, type_information)

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -3,6 +3,78 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import inspect
+import typeguard
+from typing import Any, Callable, Dict, List, Optional, Type
+from unittest.mock import NonCallableMock, _must_skip
+
+
+def get_spec_from_strict_mock(mock_obj: "StrictMock") -> Optional[Any]:
+    if "__template" in mock_obj.__dict__:
+        return mock_obj.__template
+
+    return mock_obj
+
+
+def get_spec_from_mock(mock_obj: NonCallableMock) -> Optional[Any]:
+    if "_spec_class" in mock_obj.__dict__:
+        return mock_obj._spec_class
+
+    return mock_obj
+
+
+def _unwrap_mock(
+    maybe_mock: Any, mock_extractors: Dict[Type, Callable]
+) -> Optional[Any]:
+    unwrap_func = next(
+        (
+            unwrap_func
+            for mock_class, unwrap_func in mock_extractors.items()
+            if isinstance(maybe_mock, mock_class)
+        ),
+        lambda x: x,
+    )
+
+    return unwrap_func(maybe_mock)
+
+
+def validate_function_signature(
+    argspec: inspect.FullArgSpec, args, kwargs, mock_extractors: Dict[Type, Callable]
+) -> List[TypeError]:
+    type_errs = []
+    for idx in range(0, len(args)):
+        if argspec.args:
+            arg = argspec.args[idx]
+            try:
+                __validate_argument_type(
+                    argspec.annotations, arg, args[idx], mock_extractors
+                )
+            except TypeError as te:
+                type_errs.append(te)
+    for k, v in kwargs.items():
+        try:
+            __validate_argument_type(argspec.annotations, k, v, mock_extractors)
+        except TypeError as te:
+            type_errs.append(te)
+    return type_errs
+
+
+def __validate_argument_type(
+    annotations: Dict[str, Any],
+    argname: str,
+    value: Any,
+    mock_extractors: Dict[Type, Callable],
+) -> None:
+    type_information = annotations.get(argname)
+    if type_information:
+        unwraped_value = _unwrap_mock(value, mock_extractors)
+        if unwraped_value != value and unwraped_value != type_information:
+            raise TypeError(
+                f"type of param '{argname}' must be {type_information}; got {value} instead"
+            )
+
+        else:
+            typeguard.check_type(argname, value, type_information)
 
 
 def _bail_if_private(candidate: str, allow_private: False):

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -8,12 +8,9 @@ import copy
 import functools
 import inspect
 import os.path
+from typing import Any, Optional
 from unittest.mock import NonCallableMock, _must_skip
-from testslide.lib import (
-    validate_function_signature,
-    get_spec_from_strict_mock,
-    get_spec_from_mock,
-)
+from testslide.lib import validate_function_signature
 
 
 def _wrap_signature_and_type_validation(value, template, attr_name):
@@ -730,8 +727,22 @@ class StrictMock(object):
         return self_copy
 
 
+def _get_spec_from_strict_mock(mock_obj: StrictMock) -> Optional[Any]:
+    if "_template" in mock_obj.__dict__ and mock_obj._template is not None:
+        return mock_obj._template
+
+    return mock_obj
+
+
+def _get_spec_from_mock(mock_obj: NonCallableMock) -> Optional[Any]:
+    if "_spec_class" in mock_obj.__dict__ and mock_obj._spec_class is not None:
+        return mock_obj._spec_class
+
+    return mock_obj
+
+
 MOCK_SPEC_EXTRACTORS = {
     # Add here any other mocks
-    StrictMock: get_spec_from_strict_mock,
-    NonCallableMock: get_spec_from_mock,
+    StrictMock: _get_spec_from_strict_mock,
+    NonCallableMock: _get_spec_from_mock,
 }

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -8,64 +8,12 @@ import copy
 import functools
 import inspect
 import os.path
-import typeguard
-from typing import Optional, Type
 from unittest.mock import NonCallableMock, _must_skip
-
-
-def _get_spec_from_strict_mock(mock_obj: "StrictMock") -> Optional[Type]:
-    if "__template" in mock_obj.__dict__:
-        return mock_obj.__template
-
-    return mock_obj
-
-
-def _get_spec_from_mock(mock_obj: NonCallableMock) -> Optional[Type]:
-    if "_spec_class" in mock_obj.__dict__:
-        return mock_obj._spec_class
-
-    return mock_obj
-
-
-def _unwrap_mock(maybe_mock):
-    if isinstance(maybe_mock, StrictMock):
-        return _get_spec_from_strict_mock(maybe_mock)
-
-    # all mocks in unittest.mock inherit from NonCallableMock
-    if isinstance(maybe_mock, NonCallableMock):
-        return _get_spec_from_mock(maybe_mock)
-
-    return maybe_mock
-
-def _validate_function_signature(argspec: inspect.FullArgSpec, args, kwargs):
-    type_errs = []
-    for idx in range(0, len(args)):
-        if argspec.args:
-            arg = argspec.args[idx]
-            try:
-                __validate_argument_type(argspec.annotations, arg, args[idx])
-            except TypeError as te:
-                type_errs.append(te)
-    for k, v in kwargs.items():
-        try:
-            __validate_argument_type(argspec.annotations, k, v)
-        except TypeError as te:
-            type_errs.append(te)
-    return type_errs
-
-
-def __validate_argument_type(annotations, argname, value):
-    type_information = annotations.get(argname)
-    if type_information:
-        unwraped_value = _unwrap_mock(value)
-        if unwraped_value != value and unwraped_value != type_information:
-            raise TypeError(
-                f"type of param '{argname}' must be {type_information}; got {value} instead"
-            )
-
-        else:
-            typeguard.check_type(argname, value, type_information)
-
+from testslide.lib import (
+    validate_function_signature,
+    get_spec_from_strict_mock,
+    get_spec_from_mock,
+)
 
 
 def _wrap_signature_and_type_validation(value, template, attr_name):
@@ -100,7 +48,9 @@ def _wrap_signature_and_type_validation(value, template, attr_name):
                     "{}, {}: {}".format(repr(template), repr(attr_name), str(e))
                 )
             argspec = inspect.getfullargspec(callable_template)
-            validation_errors = _validate_function_signature(argspec, args, kwargs)
+            validation_errors = validate_function_signature(
+                argspec, args, kwargs, mock_extractors=MOCK_SPEC_EXTRACTORS
+            )
             if validation_errors:
                 raise TypeError(validation_errors)
         return value(*args, **kwargs)
@@ -778,3 +728,10 @@ class StrictMock(object):
             value = copy.deepcopy(type(self).__dict__[name], memo)
             setattr(type(self_copy), name, value)
         return self_copy
+
+
+MOCK_SPEC_EXTRACTORS = {
+    # Add here any other mocks
+    StrictMock: get_spec_from_strict_mock,
+    NonCallableMock: get_spec_from_mock,
+}


### PR DESCRIPTION
We were not propely checking the signature validation when the
parameters passed were mocks and failing with TypeError.

This tries to extract the spec or template of the parameter to do the
type checking allowing to pass mocks to the functions without failing
the signature type validation.

NOTE: this assumes that all unittest.mock mocks inherit from
NonCallableMock, that assumption might change with time, though
currently seems to be the case:
```
$ grep '^class .*Mock(' /usr/lib64/python3.7/unittest/mock.py
class NonCallableMock(Base):
class Mock(CallableMixin, NonCallableMock):
class NonCallableMagicMock(MagicMixin, NonCallableMock):
class MagicMock(MagicMixin, Mock):
class PropertyMock(Mock):
```

Fixes #130