### PR TITLE
Fix memoize_before composition

### DIFF
--- a/testslide/dsl.py
+++ b/testslide/dsl.py
@@ -198,20 +198,7 @@ class _DSLContext(object):
 
         _validate_parameter(memoizable_code, "self", 0)
 
-        self.current_context.register_runtime_attribute(name)
-
-        if inspect.iscoroutinefunction(memoizable_code):
-
-            async def async_materialize_attribute(self):
-                setattr(self, name, await memoizable_code(self))
-
-            self.before(async_materialize_attribute)
-        else:
-
-            def materialize_attribute(self):
-                setattr(self, name, memoizable_code(self))
-
-            self.before(materialize_attribute)
+        self.current_context.add_memoized_attribute(name, memoizable_code, before=True)
 
         return self._not_callable
 


### PR DESCRIPTION
Composition is broken: before this fix, when a sub_context overrides a memoize_before value, it does not work: the parent value takes over.

This PR fixes that and adds a test to cover the case.