### PR TITLE
Improve type validation tests

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -1,0 +1,115 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
+import testslide.lib
+from . import sample_module
+from testslide import StrictMock
+import unittest.mock
+
+
+@context("_validate_function_signature")
+def _validate_function_signature(context):
+    @context.sub_context
+    def valid_types(context):
+        @context.function
+        def assert_passes(self, *args, **kwargs):
+            testslide.lib._validate_function_signature(
+                sample_module.test_function, args, kwargs
+            )
+
+        @context.example
+        def canonical(self):
+            self.assert_passes("arg1", "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+
+        @context.example
+        def kwargs_as_args(self):
+            self.assert_passes("arg1", "arg2", "kwarg1", "kwarg2")
+            self.assert_passes("arg1", "arg2", "kwarg1", kwarg2="kwarg2")
+
+        @context.example
+        def args_as_kwargs(self):
+            self.assert_passes("arg1", arg2="arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes(
+                arg1="arg1", arg2="arg2", kwarg1="kwarg1", kwarg2="kwarg2"
+            )
+
+        @context.example("testslide.StrictMock with valid template")
+        def testslide_StrictMock_with_valid_template(self):
+            strict_mock = StrictMock(template=str)
+            self.assert_passes(strict_mock, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", strict_mock, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1=strict_mock, kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1="kwarg1", kwarg2=strict_mock)
+
+        @context.example("testslide.StrictMock without template")
+        def testslide_StrictMock_without_template(self):
+            strict_mock = StrictMock()
+            self.assert_passes(strict_mock, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", strict_mock, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1=strict_mock, kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1="kwarg1", kwarg2=strict_mock)
+
+        @context.example("unittest.mock.Mock with valid spec")
+        def unittest_mock_Mock_with_valid_spec(self):
+            mock = unittest.mock.Mock(spec=str)
+            self.assert_passes(mock, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", mock, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1=mock, kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1="kwarg1", kwarg2=mock)
+
+        @context.example("unittest.mock.Mock without spec")
+        def unittest_mock_Mock_without_spec(self):
+            mock = unittest.mock.Mock()
+            self.assert_passes(mock, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", mock, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1=mock, kwarg2="kwarg2")
+            self.assert_passes("arg1", "arg2", kwarg1="kwarg1", kwarg2=mock)
+
+    @context.sub_context
+    def invalid_types(context):
+        @context.function
+        def assert_fails(self, *args, **kwargs):
+            with self.assertRaises(TypeError):
+                testslide.lib._validate_function_signature(
+                    sample_module.test_function, args, kwargs
+                )
+
+        @context.example
+        def canonical(self):
+            self.assert_fails(1, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails("arg1", 2, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", kwarg1=1, kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", kwarg1="kwarg1", kwarg2=2)
+
+        @context.example
+        def kwargs_as_args(self):
+            self.assert_fails("arg1", "arg2", 1, "kwarg2")
+            self.assert_fails("arg1", "arg2", "kwarg1", 2)
+            self.assert_fails("arg1", "arg2", 1, kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", "kwargs1", kwarg2=2)
+
+        @context.example
+        def args_as_kwargs(self):
+            self.assert_fails(arg1=1, arg2="arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails(arg1="arg1", arg2=2, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails(arg1="arg1", arg2="arg2", kwarg1=1, kwarg2="kwarg2")
+            self.assert_fails(arg1="arg1", arg2="arg2", kwarg1="kwarg1", kwarg2=2)
+
+        @context.example("testslide.StrictMock with invalid template")
+        def testslide_StrictMock_with_invalid_template(self):
+            strict_mock = StrictMock(template=int)
+            self.assert_fails(strict_mock, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails("arg1", strict_mock, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", kwarg1=strict_mock, kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", kwarg1="kwarg1", kwarg2=strict_mock)
+
+        @context.example("unittest.mock.Mock with valid spec")
+        def unittest_mock_Mock_with_valid_spec(self):
+            mock = unittest.mock.Mock(spec=int)
+            self.assert_fails(mock, "arg2", kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails("arg1", mock, kwarg1="kwarg1", kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", kwarg1=mock, kwarg2="kwarg2")
+            self.assert_fails("arg1", "arg2", kwarg1="kwarg1", kwarg2=mock)

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -72,9 +72,27 @@ def _validate_function_signature(context):
     def invalid_types(context):
         @context.function
         def assert_fails(self, *args, **kwargs):
-            with self.assertRaises(TypeError):
+            with self.assertRaisesRegex(
+                TypeError, "Call with incompatible argument types"
+            ):
                 testslide.lib._validate_function_signature(
                     sample_module.test_function, args, kwargs
+                )
+
+        @context.example
+        def error_message(self):
+            with self.assertRaises(
+                TypeError,
+                msg=(
+                    "Call with incompatible argument types:\n"
+                    "  'arg1': type of arg1 must be str; got int instead\n"
+                    "  'arg2': type of arg2 must be str; got int instead\n"
+                    "  'kwarg1': type of kwarg1 must be str; got int instead\n"
+                    "  'kwarg2': type of kwarg2 must be str; got int instead"
+                ),
+            ):
+                testslide.lib._validate_function_signature(
+                    sample_module.test_function, (1, 2, 3, 4), {}
                 )
 
         @context.example

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -282,10 +282,9 @@ class TestChaining(testslide.TestCase):
 class TestUsageWithPatchCallable(testslide.TestCase):
     def test_patch_callable(self):
         self.mock_callable(sample_module, "test_function").for_call(
-            testslide.matchers.AnyInstanceOf(str)
-            & testslide.matchers.RegexMatches("test.*"),
-            testslide.matchers.IntBetween(2, 4),
+            testslide.matchers.RegexMatches("foo"),
+            testslide.matchers.RegexMatches("bar"),
         ).to_return_value("mocked_response")
         with self.assertRaises(testslide.mock_callable.UnexpectedCallArguments):
-            sample_module.test_function(2, 5)
-        sample_module.test_function("testing", 3)
+            sample_module.test_function("meh", "moh")
+        sample_module.test_function("foo", "bar")

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -39,32 +39,32 @@ class TargetStr(object):
 
 class ParentTarget(TargetStr):
     def instance_method(
-        self, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+        self, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
     ):
         return "original response"
 
     async def async_instance_method(
-        self, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+        self, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
     ):
         return "async original response"
 
     @staticmethod
-    def static_method(arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None):
+    def static_method(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
         return "original response"
 
     @staticmethod
     async def async_static_method(
-        arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+        arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
     ):
         return "async original response"
 
     @classmethod
-    def class_method(cls, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None):
+    def class_method(cls, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
         return "original response"
 
     @classmethod
     async def async_class_method(
-        cls, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+        cls, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
     ):
         return "async original response"
 

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -38,26 +38,34 @@ class TargetStr(object):
 
 
 class ParentTarget(TargetStr):
-    def instance_method(self, arg1, arg2, kwarg1=None, kwarg2=None):
+    def instance_method(
+        self, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+    ):
         return "original response"
 
-    async def async_instance_method(self, arg1, arg2, kwarg1=None, kwarg2=None):
+    async def async_instance_method(
+        self, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+    ):
         return "async original response"
 
     @staticmethod
-    def static_method(arg1, arg2, kwarg1=None, kwarg2=None):
+    def static_method(arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None):
         return "original response"
 
     @staticmethod
-    async def async_static_method(arg1, arg2, kwarg1=None, kwarg2=None):
+    async def async_static_method(
+        arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+    ):
         return "async original response"
 
     @classmethod
-    def class_method(cls, arg1, arg2, kwarg1=None, kwarg2=None):
+    def class_method(cls, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None):
         return "original response"
 
     @classmethod
-    async def async_class_method(cls, arg1, arg2, kwarg1=None, kwarg2=None):
+    async def async_class_method(
+        cls, arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+    ):
         return "async original response"
 
     async def __aiter__(self):
@@ -173,26 +181,13 @@ def mock_callable_tests(context):
         ).and_assert_called_once()
         t._privatefun()
 
-    @context.example
-    def calling_patched_functions_with_bad_types_raises_TypeError(self):
-        t = TargetStr()
-        self.mock_callable(t, "typedfun").to_return_value("This is patched")
-        with self.assertRaisesRegex(
-            TypeError, "('type of a must be str; got int instead')"
-        ):
-            t.typedfun("a", 1, c=2)
-
     ##
     ## Shared Contexts
     ##
 
     @context.shared_context
     def mock_configuration_examples(
-        context,
-        callable_accepts_no_args=False,
-        has_original_callable=True,
-        can_yield=True,
-        validate_signature=True,
+        context, empty_args=False, has_original_callable=True, can_yield=True
     ):
         @context.function
         def no_behavior_msg(self):
@@ -221,23 +216,56 @@ def mock_callable_tests(context):
 
         @context.shared_context
         def mock_call_arguments(context):
-            @context.example
-            def works_for_matching_signature(self):
-                self.callable_target(*self.call_args, **self.call_kwargs),
+            @context.sub_context
+            def mock_call(context):
+                @context.sub_context
+                def signature(context):
+                    @context.example
+                    def works_with_valid_signature(self):
+                        self.callable_target(*self.call_args, **self.call_kwargs),
 
-            if validate_signature:
+                    @context.example
+                    def raises_TypeError_for_mismatching_signature(self):
+                        args = ("some", "invalid", "args", "list")
+                        kwargs = {"invalid_kwarg": "invalid_value"}
+                        with self.assertRaises(TypeError):
+                            self.callable_target(*args, **kwargs)
 
-                @context.example
-                def raises_TypeError_for_mismatching_signature(self):
-                    args = ("some", "invalid", "args", "list")
-                    kwargs = {"invalid_kwarg": "invalid_value"}
-                    with self.assertRaises(TypeError):
-                        self.callable_target(*args, **kwargs)
+                if not empty_args:
+
+                    @context.sub_context
+                    def argument_types(context):
+                        @context.example
+                        def raises_TypeError_for_mismatching_types(self):
+                            bad_signature_args = (1234 for arg in self.call_args)
+                            bad_signature_kargs = {
+                                k: 1234 for k, v in self.call_kwargs.items()
+                            }
+                            with self.assertRaises(TypeError):
+                                self.callable_target(
+                                    *bad_signature_args, **bad_signature_kargs
+                                )
 
             @context.sub_context(".for_call(*args, **kwargs)")
             def for_call_args_kwargs(context):
+                @context.sub_context
+                def with_mismatching_signature(context):
+                    @context.xexample
+                    def it_fails_to_mock(self):
+                        with self.assertRaisesWithMessage(
+                            ValueError,
+                            "Can not mock target for arguments that mismatch the "
+                            "original callable signature.",
+                        ):
+                            self.mock_callable_dsl.for_call(
+                                "some",
+                                "invalid",
+                                "args",
+                                and_some="invalid",
+                                kwargs="values",
+                            )
 
-                if not callable_accepts_no_args:
+                if not empty_args:
 
                     @context.sub_context
                     def with_matching_signature(context):
@@ -253,48 +281,25 @@ def mock_callable_tests(context):
                                 *self.specific_call_args, **self.specific_call_kwargs
                             )
 
-                        if validate_signature:
-
-                            @context.example
-                            def it_rejects_unknown_arguments(self):
-                                with self.assertRaisesWithMessage(
-                                    UnexpectedCallArguments,
-                                    self.no_behavior_msg()
-                                    + "\n  These are the registered calls:\n"
-                                    + "    {}\n".format(self.specific_call_args)
-                                    + "    {\n"
-                                    + "".join(
-                                        "      {}={},\n".format(
-                                            k, self.specific_call_kwargs[k]
-                                        )
-                                        for k in sorted(
-                                            self.specific_call_kwargs.keys()
-                                        )
+                        @context.example
+                        def it_rejects_unknown_arguments(self):
+                            with self.assertRaisesWithMessage(
+                                UnexpectedCallArguments,
+                                self.no_behavior_msg()
+                                + "\n  These are the registered calls:\n"
+                                + "    {}\n".format(self.specific_call_args)
+                                + "    {\n"
+                                + "".join(
+                                    "      {}={},\n".format(
+                                        k, self.specific_call_kwargs[k]
                                     )
-                                    + "    }\n",
-                                ):
-                                    self.callable_target(
-                                        *self.call_args, **self.call_kwargs
-                                    )
-
-                    if validate_signature:
-
-                        @context.sub_context
-                        def with_mismatching_signature(context):
-                            @context.xexample
-                            def it_fails_to_mock(self):
-                                with self.assertRaisesWithMessage(
-                                    ValueError,
-                                    "Can not mock target for arguments that mismatch the "
-                                    "original callable signature.",
-                                ):
-                                    self.mock_callable_dsl.for_call(
-                                        "some",
-                                        "invalid",
-                                        "args",
-                                        and_some="invalid",
-                                        kwargs="values",
-                                    )
+                                    for k in sorted(self.specific_call_kwargs.keys())
+                                )
+                                + "    }\n",
+                            ):
+                                self.callable_target(
+                                    *self.call_args, **self.call_kwargs
+                                )
 
         @context.shared_context
         def assertions(context):
@@ -521,7 +526,7 @@ def mock_callable_tests(context):
                 self.mock_callable_dsl.to_return_value(self.value)
 
             if has_original_callable:
-                context.nest_context("mock call arguments")
+                context.merge_context("mock call arguments")
             context.nest_context("assertions")
 
             @context.example
@@ -547,7 +552,7 @@ def mock_callable_tests(context):
                 self.mock_callable_dsl.to_return_values(self.values_list)
 
             if has_original_callable:
-                context.nest_context("mock call arguments")
+                context.merge_context("mock call arguments")
             context.nest_context("assertions")
 
             @context.example
@@ -586,7 +591,7 @@ def mock_callable_tests(context):
                     self.mock_callable_dsl.to_yield_values(self.values_list)
 
                 if has_original_callable:
-                    context.nest_context("mock call arguments")
+                    context.merge_context("mock call arguments")
                 context.nest_context("assertions")
 
                 @context.memoize
@@ -631,7 +636,7 @@ def mock_callable_tests(context):
                     self.callable_target = _callable_target
 
                 if has_original_callable:
-                    context.nest_context("mock call arguments")
+                    context.merge_context("mock call arguments")
                 context.nest_context("assertions")
 
             @context.sub_context
@@ -686,7 +691,7 @@ def mock_callable_tests(context):
                 self.mock_callable_dsl.with_implementation(self.func)
 
             if has_original_callable:
-                context.nest_context("mock call arguments")
+                context.merge_context("mock call arguments")
             context.nest_context("assertions")
 
             @context.example
@@ -717,7 +722,7 @@ def mock_callable_tests(context):
                 def setup_mock(self):
                     self.mock_callable_dsl.with_wrapper(self.wrapper_func)
 
-                context.nest_context("mock call arguments")
+                context.merge_context("mock call arguments")
                 context.nest_context("assertions")
 
                 @context.example
@@ -748,7 +753,7 @@ def mock_callable_tests(context):
                 def setup_mock(self):
                     self.mock_callable_dsl.to_call_original()
 
-                context.nest_context("mock call arguments")
+                context.merge_context("mock call arguments")
                 context.nest_context("assertions")
 
                 @context.example
@@ -768,7 +773,7 @@ def mock_callable_tests(context):
                     ):
                         self.mock_callable_dsl.to_call_original()
 
-        if not callable_accepts_no_args:
+        if not empty_args:
 
             @context.sub_context
             def composition(context):
@@ -1226,9 +1231,7 @@ def mock_callable_tests(context):
                     self.callable_target = lambda: str(self.target)
 
                 context.merge_context(
-                    "mock configuration examples",
-                    callable_accepts_no_args=True,
-                    can_yield=False,
+                    "mock configuration examples", empty_args=True, can_yield=False
                 )
 
                 @context.example
@@ -1377,7 +1380,7 @@ def mock_callable_tests(context):
 
             context.merge_context(
                 "mock configuration examples",
-                callable_accepts_no_args=True,
+                empty_args=True,
                 has_original_callable=False,
                 can_yield=False,
             )
@@ -1466,10 +1469,7 @@ def mock_async_callable_tests(context):
 
     @context.shared_context
     def mock_configuration_examples(
-        context,
-        callable_accepts_no_args=False,
-        can_yield=False,
-        has_original_callable=True,
+        context, empty_args=False, can_yield=False, has_original_callable=True
     ):
         @context.example
         async def default_behavior(self):
@@ -1859,9 +1859,7 @@ def mock_async_callable_tests(context):
                 self.call_kwargs = {}
 
             context.merge_context(
-                "mock configuration examples",
-                callable_accepts_no_args=True,
-                can_yield=False,
+                "mock configuration examples", empty_args=True, can_yield=False
             )
 
     @context.sub_context
@@ -1932,7 +1930,7 @@ def mock_async_callable_tests(context):
 
             context.merge_context(
                 "mock configuration examples",
-                callable_accepts_no_args=True,
+                empty_args=True,
                 has_original_callable=False,
                 can_yield=False,
             )

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -38,9 +38,7 @@ class TargetStr(object):
 
 
 class ParentTarget(TargetStr):
-    def instance_method(
-        self, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-    ):
+    def instance_method(self, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
         return "original response"
 
     async def async_instance_method(

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -19,13 +19,13 @@ class SomeClass:
         pass
 
 
-def test_function(arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None):
+def test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
     "This function is used by some unit tests only"
     return "original response"
 
 
 async def async_test_function(
-    arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+    arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
 ):
     "This function is used by some unit tests only"
     return "original response"

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -24,8 +24,6 @@ def test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
     return "original response"
 
 
-async def async_test_function(
-    arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-):
+async def async_test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
     "This function is used by some unit tests only"
     return "original response"

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -19,11 +19,13 @@ class SomeClass:
         pass
 
 
-def test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+def test_function(arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None):
     "This function is used by some unit tests only"
     return "original response"
 
 
-async def async_test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+async def async_test_function(
+    arg1: str, arg2: str, kwarg1: str = None, kwarg2: str = None
+):
     "This function is used by some unit tests only"
     return "original response"

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -18,7 +18,6 @@ import inspect
 import sys
 import re
 import os
-from unittest.mock import Mock
 
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 
@@ -275,156 +274,155 @@ def strict_mock(context):
             def overriding_magic_methods_work(self):
                 self.assertEqual(len(self.strict_mock), 100)
 
-        @context.shared_context
-        def regular_and_sync_methods(context):
-            @context.memoize
-            def runtime_attr(self):
-                return "some_runtime_attr"
+        @context.sub_context
+        def given_as_an_argument(context):
+            @context.sub_context
+            def sync_attributes(context):
+                context.memoize("default_context_manager", lambda self: False)
+                context.memoize("signature_validation", lambda self: True)
 
-            @context.before
-            def set_trim_path_prefix(self):
-                original_trim_path_prefix = StrictMock.TRIM_PATH_PREFIX
-                StrictMock.TRIM_PATH_PREFIX = ""
+                @context.memoize
+                def runtime_attr(self):
+                    return "some_runtime_attr"
 
-                @self.after
-                def unpatch(self):
-                    StrictMock.TRIM_PATH_PREFIX = original_trim_path_prefix
+                @context.before
+                def set_trim_path_prefix(self):
+                    original_trim_path_prefix = StrictMock.TRIM_PATH_PREFIX
+                    StrictMock.TRIM_PATH_PREFIX = ""
 
-            @context.memoize
-            def template(self):
-                return Template
+                    @self.after
+                    def unpatch(self):
+                        StrictMock.TRIM_PATH_PREFIX = original_trim_path_prefix
 
-            @context.memoize
-            def strict_mock(self):
-                return StrictMock(
-                    self.template,
-                    runtime_attrs=[self.runtime_attr],
-                    signature_validation=self.get_signature_validation(),
-                )
+                @context.memoize
+                def template(self):
+                    return Template
 
-            @context.memoize
-            def strict_mock_rgx(self):
-                return (
-                    "<StrictMock 0x{:02X} template={} ".format(
-                        id(self.strict_mock),
-                        "{}.{}".format(
-                            self.template.__module__, self.template.__name__
-                        ),
+                @context.memoize
+                def strict_mock(self):
+                    return StrictMock(
+                        self.template,
+                        runtime_attrs=[self.runtime_attr],
+                        default_context_manager=self.default_context_manager,
+                        signature_validation=self.signature_validation,
                     )
-                    + re.escape(self.caller_filename)
-                    + ":\d+>"
-                )
 
-            @context.memoize
-            def mock_function(self):
-                def mock_function(message):
-                    return "mock: {}".format(message)
+                @context.memoize
+                def strict_mock_rgx(self):
+                    return (
+                        "<StrictMock 0x{:02X} template={} ".format(
+                            id(self.strict_mock),
+                            "{}.{}".format(
+                                self.template.__module__, self.template.__name__
+                            ),
+                        )
+                        + re.escape(self.caller_filename)
+                        + ":\d+>"
+                    )
 
-                return mock_function
+                @context.memoize
+                def mock_function(self):
+                    def mock_function(message):
+                        return "mock: {}".format(message)
 
-        @context.sub_context
-        def regular_attributes(context):
-            @context.function
-            def get_signature_validation(self):
-                return True
+                    return mock_function
 
-            context.merge_context("regular and sync methods")
-
-            @context.example
-            def raises_when_an_undefined_attribute_is_accessed(self):
-                attr_name = "non_callable"
-                with self.assertRaisesWithRegexMessage(
-                    UndefinedAttribute,
-                    f"'{attr_name}' is not set.\n"
-                    f"{self.strict_mock_rgx} must have a value set "
-                    "for this attribute if it is going to be accessed.",
-                ):
-                    getattr(self.strict_mock, attr_name)
-
-            @context.example
-            def shows_the_correct_file_and_linenum_when_raising_when_an_undefined_attribute_is_accessed(
-                self,
-            ):
-                attr_name = "non_callable"
-                with self.assertRaisesWithRegexMessage(
-                    UndefinedAttribute,
-                    f"'{attr_name}' is not set.\n"
-                    f"{self.strict_mock_rgx} must have a value set "
-                    "for this attribute if it is going to be accessed.",
-                ):
-                    getattr(self.strict_mock, attr_name)
-
-            @context.example
-            def raises_when_an_non_existing_attribute_is_accessed(self):
-                attr_name = "non_existing_attr"
-                with self.assertRaisesWithRegexMessage(
-                    AttributeError,
-                    f"'{attr_name}' was not set for {self.strict_mock_rgx}.",
-                ):
-                    getattr(self.strict_mock, attr_name)
-
-            @context.example
-            def raises_when_setting_non_existing_attributes(self):
-                attr_name = "non_existing_attr"
-                with self.assertRaisesWithRegexMessage(
-                    NonExistentAttribute,
-                    f"'{attr_name}' can not be set.\n"
-                    f"{self.strict_mock_rgx} template class does not have "
-                    "this attribute so the mock can not have it as well.\n"
-                    "See also: 'runtime_attrs' at StrictMock.__init__.",
-                ):
-                    setattr(self.strict_mock, attr_name, "whatever")
-
-            @context.example
-            def allows_existing_attributes_to_be_set(self):
-                new_value = "new value"
-                self.strict_mock.non_callable = new_value
-                self.assertEqual(self.strict_mock.non_callable, new_value)
-
-            @context.example
-            def allows_init_set_attributes_to_be_set(self):
-                new_value = lambda msg: f"hello {msg}"
-                self.strict_mock.runtime_attr_from_init = new_value
-                self.assertEqual(
-                    self.strict_mock.runtime_attr_from_init("world"), "hello world"
-                )
-
-            @context.example
-            def allows_parent_init_set_attributes_to_be_set(self):
-                new_value = "new value"
-                self.strict_mock.parent_runtime_attr_from_init = new_value
-                self.assertEqual(
-                    self.strict_mock.parent_runtime_attr_from_init, new_value
-                )
-
-            @context.example
-            def can_set_runtime_attrs(self):
-                value = 3412
-                setattr(self.strict_mock, self.runtime_attr, value)
-                self.assertEqual(getattr(self.strict_mock, self.runtime_attr), value)
-
-            @context.example
-            def can_set_slots_attribute(self):
-                value = 3412
-                setattr(self.strict_mock, "slot_attribute", value)
-                self.assertEqual(getattr(self.strict_mock, "slot_attribute"), value)
-
-            @context.example
-            def attribute_type_is_maintained(self):
-                non_callable = {1: 2}
-                self.strict_mock.non_callable = non_callable
-                self.assertEqual(
-                    type(self.strict_mock.non_callable), type(non_callable)
-                )
-
-        @context.sub_context
-        def callable_attributes(context):
-            @context.shared_context
-            def callable_attributes_examples(context, signature_validation_value):
                 @context.sub_context
-                def sync_methods(context):
-                    context.merge_context("regular and sync methods")
+                def non_callable_attributes(context):
+                    @context.example
+                    def raises_when_an_undefined_attribute_is_accessed(self):
+                        attr_name = "non_callable"
+                        with self.assertRaisesWithRegexMessage(
+                            UndefinedAttribute,
+                            f"'{attr_name}' is not set.\n"
+                            f"{self.strict_mock_rgx} must have a value set "
+                            "for this attribute if it is going to be accessed.",
+                        ):
+                            getattr(self.strict_mock, attr_name)
 
+                    @context.example
+                    def shows_the_correct_file_and_linenum_when_raising_when_an_undefined_attribute_is_accessed(
+                        self,
+                    ):
+                        attr_name = "non_callable"
+                        with self.assertRaisesWithRegexMessage(
+                            UndefinedAttribute,
+                            f"'{attr_name}' is not set.\n"
+                            f"{self.strict_mock_rgx} must have a value set "
+                            "for this attribute if it is going to be accessed.",
+                        ):
+                            getattr(self.strict_mock, attr_name)
+
+                    @context.example
+                    def raises_when_an_non_existing_attribute_is_accessed(self):
+                        attr_name = "non_existing_attr"
+                        with self.assertRaisesWithRegexMessage(
+                            AttributeError,
+                            f"'{attr_name}' was not set for {self.strict_mock_rgx}.",
+                        ):
+                            getattr(self.strict_mock, attr_name)
+
+                    @context.example
+                    def raises_when_setting_non_existing_attributes(self):
+                        attr_name = "non_existing_attr"
+                        with self.assertRaisesWithRegexMessage(
+                            NonExistentAttribute,
+                            f"'{attr_name}' can not be set.\n"
+                            f"{self.strict_mock_rgx} template class does not have "
+                            "this attribute so the mock can not have it as well.\n"
+                            "See also: 'runtime_attrs' at StrictMock.__init__.",
+                        ):
+                            setattr(self.strict_mock, attr_name, "whatever")
+
+                    @context.example
+                    def allows_existing_attributes_to_be_set(self):
+                        new_value = "new value"
+                        self.strict_mock.non_callable = new_value
+                        self.assertEqual(self.strict_mock.non_callable, new_value)
+
+                    @context.example
+                    def allows_init_set_attributes_to_be_set(self):
+                        new_value = lambda msg: f"hello {msg}"
+                        self.strict_mock.runtime_attr_from_init = new_value
+                        self.assertEqual(
+                            self.strict_mock.runtime_attr_from_init("world"),
+                            "hello world",
+                        )
+
+                    @context.example
+                    def allows_parent_init_set_attributes_to_be_set(self):
+                        new_value = "new value"
+                        self.strict_mock.parent_runtime_attr_from_init = new_value
+                        self.assertEqual(
+                            self.strict_mock.parent_runtime_attr_from_init, new_value
+                        )
+
+                    @context.example
+                    def can_set_runtime_attrs(self):
+                        value = 3412
+                        setattr(self.strict_mock, self.runtime_attr, value)
+                        self.assertEqual(
+                            getattr(self.strict_mock, self.runtime_attr), value
+                        )
+
+                    @context.example
+                    def can_set_slots_attribute(self):
+                        value = 3412
+                        setattr(self.strict_mock, "slot_attribute", value)
+                        self.assertEqual(
+                            getattr(self.strict_mock, "slot_attribute"), value
+                        )
+
+                    @context.example
+                    def attribute_type_is_maintained(self):
+                        non_callable = {1: 2}
+                        self.strict_mock.non_callable = non_callable
+                        self.assertEqual(
+                            type(self.strict_mock.non_callable), type(non_callable)
+                        )
+
+                @context.sub_context
+                def callable_attributes(context):
                     @context.shared_context
                     def callable_attribute_tests(context):
                         @context.sub_context
@@ -479,192 +477,69 @@ def strict_mock(context):
                                         self.mock_function
                                     )
 
-                            if signature_validation_value:
-
-                                @context.sub_context
-                                def signature_validation(context):
-                                    @context.example
-                                    def fails_on_wrong_signature_call(self):
-                                        setattr(
-                                            self.strict_mock,
-                                            self.test_method_name,
-                                            lambda message, extra: None,
-                                        )
-                                        with self.assertRaises(TypeError):
-                                            getattr(
-                                                self.strict_mock, self.test_method_name
-                                            )("message", "extra")
-
-                                    @context.example
-                                    def works_with_wraps(self):
-                                        test_method_name = "{}_extra".format(
-                                            self.test_method_name
-                                        )
-                                        setattr(
-                                            self.strict_mock,
-                                            test_method_name,
-                                            lambda message: "mock: {}".format(message),
-                                        )
-                                        method = getattr(
-                                            self.strict_mock, test_method_name
-                                        )
-                                        self.assertEqual(method("hello"), "mock: hello")
-
-                                    @context.example
-                                    def works_when_the_parameter_passed_is_an_instance_of_Mock_with_spec(
-                                        self,
-                                    ):
-                                        class DummyParam:
-                                            def get_string():
-                                                return "DummyParam: not mocked"
-
-                                        class Dummy:
-                                            def method(self, param: DummyParam):
-                                                return f"Dummy: {param.get_string()}"
-
-                                        my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = Mock(spec=DummyParam)
-                                        my_mock.get_string.return_value = "mock_param"
-
-                                        my_strict_mock.method = (
-                                            lambda param: f"mock_method: {param.get_string()}"
-                                        )
-                                        self.assertEqual(
-                                            my_strict_mock.method(param=my_mock),
-                                            "mock_method: mock_param",
-                                        )
-
-                                    @context.example
-                                    def works_when_the_parameter_passed_is_an_instance_of_StrictMock_with_template(
-                                        self,
-                                    ):
-                                        class DummyParam:
-                                            def get_string():
-                                                return "DummyParam: not mocked"
-
-                                        class Dummy:
-                                            def method(self, param: DummyParam):
-                                                return f"Dummy: {param.get_string()}"
-
-                                        my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = StrictMock(template=DummyParam)
-                                        my_mock.get_string = lambda: "mock_param"
-
-                                        my_strict_mock.method = (
-                                            lambda param: f"mock_method: {param.get_string()}"
-                                        )
-                                        self.assertEqual(
-                                            my_strict_mock.method(param=my_mock),
-                                            "mock_method: mock_param",
-                                        )
-
-                                    @context.example
-                                    def fails_when_the_parameter_passed_is_an_instance_of_Mock_with_wrong_spec(
-                                        self,
-                                    ):
-                                        class DummyParam:
-                                            def get_string():
-                                                return "DummyParam: not mocked"
-
-                                        class Dummy:
-                                            def method(self, param: DummyParam):
-                                                return f"Dummy: {param.get_string()}"
-
-                                        my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = Mock(spec=Template)
-
-                                        my_strict_mock.method = (
-                                            lambda param: f"mock_method: {param.get_string()}"
-                                        )
-                                        with self.assertRaises(TypeError):
-                                            my_strict_mock.method(param=my_mock)
-
-                                    @context.example
-                                    def fails_when_the_parameter_passed_is_an_instance_of_StrictMock_with_wrong_template(
-                                        self,
-                                    ):
-                                        class DummyParam:
-                                            def get_string():
-                                                return "DummyParam: not mocked"
-
-                                        class Dummy:
-                                            def method(self, param: DummyParam):
-                                                return f"Dummy: {param.get_string()}"
-
-                                        my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = StrictMock(template=Template)
-
-                                        my_strict_mock.method = (
-                                            lambda param: f"mock_method: {param.get_string()}"
-                                        )
-                                        with self.assertRaises(TypeError):
-                                            my_strict_mock.method(param=my_mock)
-
-                                    @context.example
-                                    def works_when_the_parameter_passed_is_an_instance_of_Mock_without_spec(
-                                        self,
-                                    ):
-                                        class DummyParam:
-                                            def get_string():
-                                                return "DummyParam: not mocked"
-
-                                        class Dummy:
-                                            def method(self, param: DummyParam):
-                                                return f"Dummy: {param.get_string()}"
-
-                                        my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = Mock()
-                                        my_mock.get_string.return_value = "mock_param"
-
-                                        my_strict_mock.method = (
-                                            lambda param: f"mock_method: {param.get_string()}"
-                                        )
-                                        self.assertEqual(
-                                            my_strict_mock.method(param=my_mock),
-                                            "mock_method: mock_param",
-                                        )
-
-                                    @context.example
-                                    def works_when_the_parameter_passed_is_an_instance_of_StrictMock_without_template(
-                                        self,
-                                    ):
-                                        class DummyParam:
-                                            def get_string():
-                                                return "DummyParam: not mocked"
-
-                                        class Dummy:
-                                            def method(self, param: DummyParam):
-                                                return f"Dummy: {param.get_string()}"
-
-                                        my_strict_mock = StrictMock(template=Dummy)
-                                        my_mock = StrictMock()
-                                        my_mock.get_string = lambda: "mock_param"
-
-                                        my_strict_mock.method = (
-                                            lambda param: f"mock_method: {param.get_string()}"
-                                        )
-                                        self.assertEqual(
-                                            my_strict_mock.method(param=my_mock),
-                                            "mock_method: mock_param",
-                                        )
-
-                            else:
-
+                            @context.sub_context
+                            def signature_validation(context):
                                 @context.example
-                                def attribute_type_is_maintained(self):
+                                def fails_on_wrong_signature_call(self):
                                     setattr(
                                         self.strict_mock,
                                         self.test_method_name,
-                                        self.mock_function,
+                                        lambda message, extra: None,
                                     )
-                                    self.assertEqual(
-                                        type(
+                                    with self.assertRaises(TypeError):
+                                        getattr(
+                                            self.strict_mock, self.test_method_name
+                                        )("message", "extra")
+
+                                @context.example
+                                def works_with_wraps(self):
+                                    test_method_name = "{}_extra".format(
+                                        self.test_method_name
+                                    )
+                                    setattr(
+                                        self.strict_mock,
+                                        test_method_name,
+                                        lambda message: "mock: {}".format(message),
+                                    )
+                                    method = getattr(self.strict_mock, test_method_name)
+                                    self.assertEqual(method("hello"), "mock: hello")
+
+                                @context.sub_context("with signature_validation=False")
+                                def with_signature_validation_False(context):
+                                    context.memoize(
+                                        "signature_validation", lambda self: False
+                                    )
+
+                                    @context.example
+                                    def passes_on_wrong_signature_call(self):
+                                        setattr(
+                                            self.strict_mock,
+                                            self.test_method_name,
+                                            lambda message, extra: "mock",
+                                        )
+                                        self.assertEqual(
                                             getattr(
                                                 self.strict_mock, self.test_method_name
-                                            )
-                                        ),
-                                        type(self.mock_function),
-                                    )
+                                            )("message", "extra"),
+                                            "mock",
+                                        )
+
+                                    @context.example
+                                    def attribute_type_is_maintained(self):
+                                        setattr(
+                                            self.strict_mock,
+                                            self.test_method_name,
+                                            self.mock_function,
+                                        )
+                                        self.assertEqual(
+                                            type(
+                                                getattr(
+                                                    self.strict_mock,
+                                                    self.test_method_name,
+                                                )
+                                            ),
+                                            type(self.mock_function),
+                                        )
 
                         @context.sub_context
                         def success(context):
@@ -792,96 +667,89 @@ def strict_mock(context):
                             def template(self):
                                 return ContextManagerTemplate
 
+                            @context.example
+                            def context_manager_raises_UndefinedAttribute(self):
+                                with self.assertRaisesWithRegexMessage(
+                                    UndefinedAttribute,
+                                    f"'__enter__' is not set.\n"
+                                    f"{self.strict_mock_rgx} must have a value set "
+                                    "for this attribute if it is going to be accessed.",
+                                ):
+                                    with self.strict_mock:
+                                        pass
+
                             @context.sub_context("with default_context_manager=True")
                             def with_default_context_manager_True(context):
-                                @context.memoize
-                                def strict_mock(self):
-                                    return StrictMock(
-                                        template=self.template,
-                                        default_context_manager=True,
-                                    )
+                                context.memoize(
+                                    "default_context_manager", lambda self: True
+                                )
 
                                 @context.example
-                                def context_manager_works(self):
+                                def it_yields_the_mock(self):
                                     with self.strict_mock as target:
                                         self.assertTrue(target is self.strict_mock)
 
-                            @context.sub_context("with default_context_manager=False")
-                            def with_default_context_manager_False(context):
-                                @context.memoize
-                                def strict_mock(self):
-                                    return StrictMock(
-                                        template=self.template,
-                                        default_context_manager=False,
-                                    )
+            @context.sub_context
+            def async_attributes(context):
+                @context.memoize_before
+                async def default_context_manager(self):
+                    return False
 
-                                @context.example
-                                def context_manager_raises_UndefinedAttribute(self):
-                                    with self.assertRaisesWithRegexMessage(
-                                        UndefinedAttribute,
-                                        f"'__enter__' is not set.\n"
-                                        f"{self.strict_mock_rgx} must have a value set "
-                                        "for this attribute if it is going to be accessed.",
-                                    ):
-                                        with self.strict_mock:
-                                            pass
+                @context.memoize_before
+                async def signature_validation(self):
+                    return True
 
-                @context.sub_context
-                def async_methods(context):
-                    @context.memoize_before
-                    async def strict_mock(self):
-                        return StrictMock(
-                            template=Template,
-                            signature_validation=self.get_signature_validation(),
+                @context.memoize_before
+                async def strict_mock(self):
+                    return StrictMock(
+                        template=Template,
+                        default_context_manager=self.default_context_manager,
+                        signature_validation=self.signature_validation,
+                    )
+
+                @context.shared_context
+                def async_method_tests(context):
+                    @context.example
+                    async def raises_when_setting_a_non_callable_value(self):
+                        with self.assertRaisesWithRegexMessage(
+                            NonCallableValue,
+                            f"'{self.method_name}' can not be set with a "
+                            "non-callable value.\n"
+                            f"<StrictMock .+> template class requires "
+                            "this attribute to be callable.",
+                        ):
+                            setattr(self.strict_mock, self.method_name, "not callable")
+
+                    @context.example
+                    async def can_mock_with_async_function(self):
+                        async def mock(msg):
+                            return "mock " + msg
+
+                        setattr(self.strict_mock, self.method_name, mock)
+                        self.assertEqual(
+                            await getattr(self.strict_mock, self.method_name)("hello"),
+                            "mock hello",
                         )
 
-                    @context.shared_context
-                    def async_method_tests(context):
+                    @context.sub_context
+                    def signature_validation(context):
                         @context.example
-                        async def raises_when_setting_a_non_callable_value(self):
+                        async def raises_when_non_async_function_assigned(self):
+                            def sync_mock(msg):
+                                return "mock"
+
+                            setattr(self.strict_mock, self.method_name, sync_mock)
+
                             with self.assertRaisesWithRegexMessage(
-                                NonCallableValue,
-                                f"'{self.method_name}' can not be set with a "
-                                "non-callable value.\n"
-                                f"<StrictMock .+> template class requires "
-                                "this attribute to be callable.",
+                                NonAwaitableReturn,
+                                f"'{self.method_name}' can not be set with a callable "
+                                "that does not return an awaitable.\n"
+                                "<StrictMock .+> template class requires this attribute to "
+                                "be a callable that returns an awaitable \(eg: a 'async "
+                                "def' function\).",
                             ):
-                                setattr(
-                                    self.strict_mock, self.method_name, "not callable"
-                                )
-
-                        if signature_validation_value:
-
-                            @context.example
-                            async def raises_when_non_async_function_assigned(self):
-                                def sync_mock(msg):
-                                    return "mock"
-
-                                setattr(self.strict_mock, self.method_name, sync_mock)
-
-                                with self.assertRaisesWithRegexMessage(
-                                    NonAwaitableReturn,
-                                    f"'{self.method_name}' can not be set with a callable "
-                                    "that does not return an awaitable.\n"
-                                    "<StrictMock .+> template class requires this attribute to "
-                                    "be a callable that returns an awaitable \(eg: a 'async "
-                                    "def' function\).",
-                                ):
-                                    await getattr(self.strict_mock, self.method_name)(
-                                        "hello"
-                                    )
-
-                        else:
-
-                            @context.example
-                            async def attribute_type_is_maintained(self):
-                                async def mock(msg):
-                                    return "mock " + msg
-
-                                setattr(self.strict_mock, self.method_name, mock)
-                                self.assertEqual(
-                                    type(getattr(self.strict_mock, self.method_name)),
-                                    type(mock),
+                                await getattr(self.strict_mock, self.method_name)(
+                                    "hello"
                                 )
 
                         @context.example
@@ -895,141 +763,128 @@ def strict_mock(context):
                                     "hello", "wrong"
                                 )
 
-                        @context.example
-                        async def can_mock_with_async_function(self):
-                            async def mock(msg):
-                                return "mock " + msg
-
-                            setattr(self.strict_mock, self.method_name, mock)
-                            self.assertEqual(
-                                await getattr(self.strict_mock, self.method_name)(
-                                    "hello"
-                                ),
-                                "mock hello",
-                            )
-
-                    @context.sub_context
-                    def instance_methods(context):
-                        @context.memoize_before
-                        async def method_name(self):
-                            return "async_instance_method"
-
-                        context.merge_context("async method tests")
-
-                    @context.sub_context
-                    def static_methods(context):
-                        @context.memoize_before
-                        async def method_name(self):
-                            return "async_static_method"
-
-                        context.merge_context("async method tests")
-
-                    @context.sub_context
-                    def class_methods(context):
-                        @context.memoize_before
-                        async def method_name(self):
-                            return "async_class_method"
-
-                        context.merge_context("async method tests")
-
-                    @context.sub_context
-                    def async_iterator(context):
-                        @context.example
-                        async def default_raises_UndefinedAttribute(self):
-                            with self.assertRaisesWithRegexMessage(
-                                UndefinedAttribute,
-                                f"'__aiter__' is not set.\n"
-                                f"<StrictMock .+> must have a value set "
-                                "for this attribute if it is going to be accessed.",
-                            ):
-                                async for _ in self.strict_mock:
-                                    pass
-
-                        @context.example
-                        async def can_mock_async_iterator(self):
-                            self.strict_mock.__aiter__ = lambda: self.strict_mock
-                            expected_values = [3, 4, 5]
-                            mock_values = copy.copy(expected_values)
-
-                            async def mock():
-                                if mock_values:
-                                    return mock_values.pop()
-                                raise StopAsyncIteration
-
-                            self.strict_mock.__anext__ = mock
-                            yielded_values = []
-                            async for v in self.strict_mock:
-                                yielded_values.append(v)
-                            self.assertEqual(
-                                expected_values, list(reversed(yielded_values))
-                            )
-
-                    @context.sub_context
-                    def async_context_manager(context):
-                        @context.sub_context("default_context_manager=False")
-                        def default_context_manager_False(context):
+                        @context.sub_context("with signature_validation=False")
+                        def with_signature_validation_False(context):
                             @context.memoize_before
-                            async def strict_mock(self):
-                                return StrictMock(
-                                    template=Template, default_context_manager=False
+                            async def signature_validation(self):
+                                return False
+
+                            @context.example
+                            async def passes_on_wrong_signature_call(self):
+                                async def mock(msg, extra):
+                                    return "mock"
+
+                                setattr(self.strict_mock, self.method_name, mock)
+                                self.assertEqual(
+                                    await getattr(self.strict_mock, self.method_name)(
+                                        "hello", "wrong"
+                                    ),
+                                    "mock",
                                 )
 
                             @context.example
-                            async def default_raises_UndefinedAttribute(self):
-                                with self.assertRaisesWithRegexMessage(
-                                    UndefinedAttribute,
-                                    f"'__aenter__' is not set.\n"
-                                    f"<StrictMock .+> must have a value set "
-                                    "for this attribute if it is going to be accessed.",
-                                ):
-                                    async with self.strict_mock:
-                                        pass
+                            async def attribute_type_is_maintained(self):
+                                async def mock(msg):
+                                    return "mock " + msg
 
-                            @context.example
-                            async def can_mock_async_context_manager(self):
-                                async def aenter():
-                                    return "yielded"
-
-                                async def aexit(exc_type, exc_value, traceback):
-                                    pass
-
-                                self.strict_mock.__aenter__ = aenter
-                                self.strict_mock.__aexit__ = aexit
-                                async with self.strict_mock as m:
-                                    assert m == "yielded"
-
-                        @context.sub_context("default_context_manager=True")
-                        def default_context_manager_True(context):
-                            @context.memoize_before
-                            async def strict_mock(self):
-                                return StrictMock(
-                                    template=Template, default_context_manager=True
+                                setattr(self.strict_mock, self.method_name, mock)
+                                self.assertEqual(
+                                    type(getattr(self.strict_mock, self.method_name)),
+                                    type(mock),
                                 )
 
-                            @context.example
-                            async def it_works(self):
-                                async with self.strict_mock as m:
-                                    assert id(self.strict_mock) == id(m)
+                @context.sub_context
+                def instance_methods(context):
+                    @context.memoize_before
+                    async def method_name(self):
+                        return "async_instance_method"
 
-            @context.sub_context("with signature_validation=True")
-            def with_signature_validation_True(context):
-                @context.function
-                def get_signature_validation(self):
-                    return True
+                    context.merge_context("async method tests")
 
-                context.merge_context(
-                    "callable attributes examples", signature_validation_value=True
-                )
+                @context.sub_context
+                def static_methods(context):
+                    @context.memoize_before
+                    async def method_name(self):
+                        return "async_static_method"
 
-            @context.sub_context("with signature_validation=False")
-            def with_signature_validation_False(context):
-                @context.function
-                def get_signature_validation(self):
-                    return False
+                    context.merge_context("async method tests")
 
-                context.merge_context(
-                    "callable attributes examples", signature_validation_value=False
-                )
+                @context.sub_context
+                def class_methods(context):
+                    @context.memoize_before
+                    async def method_name(self):
+                        return "async_class_method"
+
+                    context.merge_context("async method tests")
+
+                @context.sub_context
+                def async_iterator(context):
+                    @context.example
+                    async def default_raises_UndefinedAttribute(self):
+                        with self.assertRaisesWithRegexMessage(
+                            UndefinedAttribute,
+                            f"'__aiter__' is not set.\n"
+                            f"<StrictMock .+> must have a value set "
+                            "for this attribute if it is going to be accessed.",
+                        ):
+                            async for _ in self.strict_mock:
+                                pass
+
+                    @context.example
+                    async def can_mock_async_iterator(self):
+                        self.strict_mock.__aiter__ = lambda: self.strict_mock
+                        expected_values = [3, 4, 5]
+                        mock_values = copy.copy(expected_values)
+
+                        async def mock():
+                            if mock_values:
+                                return mock_values.pop()
+                            raise StopAsyncIteration
+
+                        self.strict_mock.__anext__ = mock
+                        yielded_values = []
+                        async for v in self.strict_mock:
+                            yielded_values.append(v)
+                        self.assertEqual(
+                            expected_values, list(reversed(yielded_values))
+                        )
+
+                @context.sub_context
+                def async_context_manager(context):
+                    @context.example
+                    async def default_raises_UndefinedAttribute(self):
+                        with self.assertRaisesWithRegexMessage(
+                            UndefinedAttribute,
+                            f"'__aenter__' is not set.\n"
+                            f"<StrictMock .+> must have a value set "
+                            "for this attribute if it is going to be accessed.",
+                        ):
+                            async with self.strict_mock:
+                                pass
+
+                    @context.example
+                    async def can_mock_async_context_manager(self):
+                        async def aenter():
+                            return "yielded"
+
+                        async def aexit(exc_type, exc_value, traceback):
+                            pass
+
+                        self.strict_mock.__aenter__ = aenter
+                        self.strict_mock.__aexit__ = aexit
+                        async with self.strict_mock as m:
+                            assert m == "yielded"
+
+                    @context.sub_context("default_context_manager=True")
+                    def default_context_manager_True(context):
+                        @context.memoize_before
+                        async def default_context_manager(self):
+                            return True
+
+                        @context.example
+                        async def it_yields_the_mock(self):
+                            async with self.strict_mock as m:
+                                assert id(self.strict_mock) == id(m)
 
     @context.sub_context
     def making_copies(context):

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -452,31 +452,6 @@ def strict_mock(context):
                                 ):
                                     getattr(self.strict_mock, self.test_method_name)
 
-                            @context.example
-                            def raises_when_a_non_existing_method_is_accessed(self):
-                                attr_name = "non_existing_method"
-                                with self.assertRaisesWithRegexMessage(
-                                    AttributeError,
-                                    f"'{attr_name}' was not set for "
-                                    f"{self.strict_mock_rgx}.",
-                                ):
-                                    getattr(self.strict_mock, attr_name)
-
-                            @context.example
-                            def raises_when_setting_non_existing_methods(self):
-                                attr_name = "non_existing_method"
-                                with self.assertRaisesWithRegexMessage(
-                                    NonExistentAttribute,
-                                    f"'{attr_name}' can not be set.\n"
-                                    f"{self.strict_mock_rgx} template class does not "
-                                    "have this attribute so the mock can not have it "
-                                    "as well.\n"
-                                    "See also: 'runtime_attrs' at StrictMock.__init__.",
-                                ):
-                                    self.strict_mock.non_existing_method = (
-                                        self.mock_function
-                                    )
-
                             @context.sub_context
                             def signature_validation(context):
                                 @context.example

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -4,53 +4,63 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import inspect
+import functools
 import typeguard
-from typing import Any, Callable, Dict, Iterable, Optional, Type, Tuple
+from typing import Any, Callable, Dict, Optional, Type, Tuple
+
+import unittest.mock
 
 ##
 ## Type validation
 ##
 
 
-def _unwrap_mock(
-    maybe_mock: Any, mock_extractors: Dict[Type, Callable]
-) -> Optional[Any]:
-    unwrap_func = next(
-        (
-            unwrap_func
-            for mock_class, unwrap_func in mock_extractors.items()
-            if isinstance(maybe_mock, mock_class)
-        ),
-        lambda x: x,
+def _extract_NonCallableMock_template(mock_obj) -> Optional[Any]:
+    if "_spec_class" in mock_obj.__dict__ and mock_obj._spec_class is not None:
+        return mock_obj._spec_class
+
+    return None
+
+
+MOCK_TEMPLATE_EXTRACTORS: Dict[Type, Callable[[Type], Optional[Any]]] = {
+    unittest.mock.NonCallableMock: _extract_NonCallableMock_template
+}
+
+
+def _extract_mock_template(mock):
+    template = None
+    for mock_class, extract_mock_template in MOCK_TEMPLATE_EXTRACTORS.items():
+        if isinstance(mock, mock_class):
+            template = extract_mock_template(mock)
+    return template
+
+
+def _is_a_mock(maybe_mock: Any) -> bool:
+    return any(
+        isinstance(maybe_mock, mock_class)
+        for mock_class in MOCK_TEMPLATE_EXTRACTORS.keys()
     )
-
-    return unwrap_func(maybe_mock)
-
-
-def _is_a_mock(maybe_mock: Any, mock_classes: Iterable[Type]) -> bool:
-    return any(isinstance(maybe_mock, mock_class) for mock_class in mock_classes)
 
 
 def _validate_argument_type(
-    annotations: Dict[str, Any],
-    argname: str,
-    value: Any,
-    mock_extractors: Dict[Type, Callable],
+    annotations: Dict[str, Any], argname: str, value: Any
 ) -> None:
     type_information = annotations.get(argname)
-    if type_information:
-        unwrapped_value = _unwrap_mock(value, mock_extractors)
-        if _is_a_mock(unwrapped_value, mock_classes=mock_extractors.keys()):
-            return
+    if not type_information:
+        return
+
+    if _is_a_mock(value):
+        template = _extract_mock_template(value)
+        if template:
+            value = template
         else:
-            typeguard.check_type(argname, value, type_information)
+            return
+
+    typeguard.check_type(argname, value, type_information)
 
 
 def _validate_function_signature(
-    callable_template: Callable,
-    args: Tuple[Any],
-    kwargs: Dict[str, Any],
-    mock_extractors: Dict[Type, Callable],
+    callable_template: Callable, args: Tuple[Any], kwargs: Dict[str, Any]
 ):
     argspec = inspect.getfullargspec(callable_template)
     try:
@@ -67,22 +77,54 @@ def _validate_function_signature(
             else:
                 argname = argspec.args[idx]
             try:
-                _validate_argument_type(
-                    argspec.annotations, argname, args[idx], mock_extractors
-                )
+                _validate_argument_type(argspec.annotations, argname, args[idx])
             except TypeError as type_error:
                 type_errors.append(f"{repr(argname)}: {type_error}")
     for argname, value in kwargs.items():
         try:
-            _validate_argument_type(
-                argspec.annotations, argname, value, mock_extractors
-            )
+            _validate_argument_type(argspec.annotations, argname, value)
         except TypeError as type_error:
             type_errors.append(f"{repr(argname)}: {type_error}")
     if type_errors:
         raise TypeError(
             "Call with incompatible argument types:\n  " + "\n  ".join(type_errors)
         )
+
+
+def _wrap_signature_and_type_validation(value, template, attr_name):
+    if _is_a_mock(template):
+        template = _extract_mock_template(template)
+        if not template:
+            return value
+
+    # This covers runtime attributes
+    if not hasattr(template, attr_name):
+        return value
+
+    callable_template = getattr(template, attr_name)
+
+    # FIXME decouple from _must_skip. It tells when self should be skipped
+    # for signature validation.
+    if unittest.mock._must_skip(template, attr_name, isinstance(template, type)):
+        callable_template = functools.partial(callable_template, None)
+
+    try:
+        signature = inspect.signature(callable_template, follow_wrapped=False)
+    except ValueError:
+        signature = None
+
+    def with_sig_check(*args, **kwargs):
+        if signature:
+            try:
+                signature.bind(*args, **kwargs)
+            except TypeError as e:
+                raise TypeError(
+                    "{}, {}: {}".format(repr(template), repr(attr_name), str(e))
+                )
+            _validate_function_signature(callable_template, args, kwargs)
+        return value(*args, **kwargs)
+
+    return with_sig_check
 
 
 ##

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -51,11 +51,8 @@ def _validate_argument_type(
 
     if _is_a_mock(value):
         template = _extract_mock_template(value)
-        if template:
-            value = template
-        else:
+        if not template:
             return
-
     typeguard.check_type(argname, value, type_information)
 
 

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import inspect
 import typeguard
-from typing import Any, Callable, Dict, Iterable, List, Optional, Type
+from typing import Any, Callable, Dict, Iterable, Optional, Type
 
 
 def _unwrap_mock(

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -90,7 +90,7 @@ def _validate_function_signature(
 ##
 
 
-def _bail_if_private(candidate: str, allow_private: False):
+def _bail_if_private(candidate: str, allow_private: bool):
     if (
         candidate.startswith("_")
         and not allow_private

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -55,9 +55,7 @@ def validate_function_signature(
             type_errors.append(f"{repr(argname)}: {type_error}")
     if type_errors:
         raise TypeError(
-            "Call with incompatible argument types:\n  "
-            +
-            "\n  ".join(type_errors)
+            "Call with incompatible argument types:\n  " + "\n  ".join(type_errors)
         )
 
 

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -9,7 +9,7 @@ import functools
 from typing import List, Callable  # noqa
 import testslide
 from testslide.strict_mock import StrictMock
-from testslide.strict_mock import _wrap_signature_and_type_validation
+from testslide.lib import _wrap_signature_and_type_validation
 from .patch import _patch, _is_instance_method
 from .lib import _bail_if_private
 

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -10,7 +10,7 @@ import inspect
 import os.path
 from typing import Any, Optional
 from unittest.mock import NonCallableMock, _must_skip
-from testslide.lib import validate_function_signature
+from testslide.lib import _validate_function_signature
 
 
 def _wrap_signature_and_type_validation(value, template, attr_name):
@@ -44,7 +44,7 @@ def _wrap_signature_and_type_validation(value, template, attr_name):
                 raise TypeError(
                     "{}, {}: {}".format(repr(template), repr(attr_name), str(e))
                 )
-            validate_function_signature(
+            _validate_function_signature(
                 callable_template, args, kwargs, mock_extractors=MOCK_SPEC_EXTRACTORS
             )
         return value(*args, **kwargs)

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -44,12 +44,9 @@ def _wrap_signature_and_type_validation(value, template, attr_name):
                 raise TypeError(
                     "{}, {}: {}".format(repr(template), repr(attr_name), str(e))
                 )
-            argspec = inspect.getfullargspec(callable_template)
-            validation_errors = validate_function_signature(
-                argspec, args, kwargs, mock_extractors=MOCK_SPEC_EXTRACTORS
+            validate_function_signature(
+                callable_template, args, kwargs, mock_extractors=MOCK_SPEC_EXTRACTORS
             )
-            if validation_errors:
-                raise TypeError(validation_errors)
         return value(*args, **kwargs)
 
     return with_sig_check


### PR DESCRIPTION
Add more thorough testing to type checking:

- `tests/lib_testslide.py` added with more cases variation.
- `StrictMock` & `mock_callable()` had type checking tests added for all use cases (module function / instance/class/static methods).
  - Found an issue with type checking for class methods.

Along the way:

- Fixed type checking for class methods.
- Fixed type checking error message.
  - It was an aggregation of `TypeError` messages which would not match the existing error.
  - It now shows each error on a separate line:
```
TypeError: Call with incompatible argument types:
  'arg1': type of arg1 must be str; got int instead
  'arg2': type of arg2 must be str; got int instead
  'kwarg1': type of kwarg1 must be str; got int instead
  'kwarg2': type of kwarg2 must be str; got int instead"
```
- Moved all common stuff to `testslide/lib` .
- Integrated common logic for extracting methods from mocks into `_wrap_signature_and_type_validation`, so `StrictMock` & `mock_callable` now works with other mocks.