### PR TITLE
Add tests for return value type validation & finish them

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -30,7 +30,7 @@ class TargetStr(object):
         a: str,
         b: typing.Iterable[typing.Union[str, float]],
         c: typing.Optional[str],
-    ):
+    ) -> str:
         return "asd"
 
     def _privatefun(self):
@@ -179,6 +179,18 @@ def mock_callable_tests(context):
             "This fun is private"
         ).and_assert_called_once()
         t._privatefun()
+
+    @context.example
+    def patching_typed_functions_raises_typeerror_with_invalid_responsetype(self):
+        t = TargetStr()
+        with self.assertRaises(TypeError):
+            self.mock_callable(t, "typedfun").to_return_value(1)
+
+    @context.example
+    def patching_typed_functions_raises_typeerror_with_invalid_responsetypes(self):
+        t = TargetStr()
+        with self.assertRaises(TypeError):
+            self.mock_callable(t, "typedfun").to_return_values(["a", 1])
 
     ##
     ## Shared Contexts

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -19,11 +19,13 @@ class SomeClass:
         pass
 
 
-def test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
+def test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = "") -> str:
     "This function is used by some unit tests only"
     return "original response"
 
 
-async def async_test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""):
+async def async_test_function(
+    arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
+) -> str:
     "This function is used by some unit tests only"
     return "original response"

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -125,6 +125,14 @@ def _wrap_signature_validation(value, template, attr_name, validate_types):
     return with_sig_check
 
 
+def _validate_return_type(template, value):
+    try:
+        argspec = inspect.getfullargspec(template)
+    except TypeError:
+        return
+    _validate_argument_type(argspec.annotations, "return", value)
+
+
 ##
 ## Private attributes
 ##


### PR DESCRIPTION
This PR builds on top of #139 by @deathowl :

- Add tests for `mock_callable` & `mock_async_callable`.
- Fix broken cases.