### PR TITLE
Add Long Formatter

### DIFF
--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -254,7 +254,7 @@ class TestCliQuiet(TestCliBase):
         )
 
 
-class TestCliDocumentation(TestCliBase):
+class TestCliDocumentationFormatter(TestCliBase):
     def setUp(self):
         super().setUp()
         self.argv = ["--format", "documentation"] + self.argv
@@ -520,7 +520,7 @@ class TestCliDocumentation(TestCliBase):
         )
 
 
-class TestCliProgress(TestCliBase):
+class TestCliProgressFormatter(TestCliBase):
     def setUp(self):
         super().setUp()
         self.argv.append("--format")
@@ -544,5 +544,114 @@ class TestCliProgress(TestCliBase):
                 + self.green(".")
                 + self.yellow("S")
                 + "\r\n"
+            ),
+        )
+
+
+class TestCliLongFormatter(TestCliBase):
+    def setUp(self):
+        super().setUp()
+        self.argv = ["--format", "long"] + self.argv
+
+    def test_colored_output_to_terminal(self):
+        """
+        Execute all examples in the order defined with colored output.
+        """
+        self.run_testslide(
+            tty_stdout=True,
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                self.white("top context: ")
+                + self.green("passing example")
+                + "\r\n"
+                + self.white("top context: ")
+                + self.red("failing example: ")
+                + "SimulatedFailure: test failure (extra)"
+                + "\r\n"
+                + self.white("top context: ")
+                + self.green("*focused example")
+                + "\r\n"
+                + self.white("top context: ")
+                + self.yellow("skipped example")
+                + "\r\n"
+                + self.white("top context: ")
+                + self.yellow("unittest SkipTest")
+                + "\r\n"
+                + self.white("top context, nested context: ")
+                + self.green("passing nested example")
+                + "\r\n"
+                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.red("test_failing: ")
+                + "AssertionError: "
+                + "\r\n"
+                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.green("test_passing")
+                + "\r\n"
+                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.yellow("test_skipped")
+                + "\r\n"
+                # TODO Rest of the output
+            ),
+        )
+
+    def test_colored_output_with_force_color(self):
+        """
+        Execute all examples in the order defined with colored output.
+        """
+        self.argv.append("--force-color")
+
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                self.white("top context: ")
+                + self.green("passing example")
+                + "\n"
+                + self.white("top context: ")
+                + self.red("failing example: ")
+                + "SimulatedFailure: test failure (extra)"
+                + "\n"
+                + self.white("top context: ")
+                + self.green("*focused example")
+                + "\n"
+                + self.white("top context: ")
+                + self.yellow("skipped example")
+                + "\n"
+                + self.white("top context: ")
+                + self.yellow("unittest SkipTest")
+                + "\n"
+                + self.white("top context, nested context: ")
+                + self.green("passing nested example")
+                + "\n"
+                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.red("test_failing: ")
+                + "AssertionError: "
+                + "\n"
+                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.green("test_passing")
+                + "\n"
+                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.yellow("test_skipped")
+                + "\n"
+                # TODO Rest of the output
+            ),
+        )
+
+    def test_plain_output_without_terminal(self):
+        """
+        Execute all examples in the order defined without color.
+        """
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context: passing example: PASS\n"
+                "top context: failing example: SimulatedFailure: test failure (extra)\n"
+                "top context: *focused example: PASS\n"
+                "top context: skipped example: SKIP\n"
+                "top context: unittest SkipTest: SKIP\n"
+                "top context, nested context: passing nested example: PASS\n"
+                "tests.sample_tests.SampleTestCase: test_failing: AssertionError: \n"
+                "tests.sample_tests.SampleTestCase: test_passing: PASS\n"
+                "tests.sample_tests.SampleTestCase: test_skipped: SKIP\n"
+                # TODO rest of output
             ),
         )

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -312,7 +312,7 @@ class TestCliDocumentationFormatter(TestCliBase):
                 + "\n"
                 + self.green("    passing nested example")
                 + "\n"
-                # TODO rest of output
+                # TODO add remaining bits of the output (using regexes)
             ),
         )
 
@@ -337,7 +337,7 @@ class TestCliDocumentationFormatter(TestCliBase):
                 "  test_skipped: SKIP\n"
                 "\n"
                 "Failures:\n"
-                # TODO rest of output
+                # TODO add remaining bits of the output (using regexes)
             ),
         )
 
@@ -366,7 +366,7 @@ class TestCliDocumentationFormatter(TestCliBase):
                 "  *focused example: PASS\n"
                 "\n"
                 "Failures:\n"
-                # TODO rest of output
+                # TODO add remaining bits of the output (using regexes)
             ),
         )
 
@@ -381,7 +381,7 @@ class TestCliDocumentationFormatter(TestCliBase):
                 "  *focused example: PASS\n"
                 "\n"
                 "Finished 1 example(s) in "
-                # TODO rest of output
+                # TODO add remaining bits of the output (using regexes)
             )
         )
 
@@ -652,6 +652,6 @@ class TestCliLongFormatter(TestCliBase):
                 "tests.sample_tests.SampleTestCase: test_failing: AssertionError: \n"
                 "tests.sample_tests.SampleTestCase: test_passing: PASS\n"
                 "tests.sample_tests.SampleTestCase: test_skipped: SKIP\n"
-                # TODO rest of output
+                # TODO add remaining bits of the output (using regexes)
             ),
         )

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -12,7 +12,7 @@ import sys
 from contextlib import contextmanager
 
 from . import _TestSlideTestResult, Context
-from .runner import Runner, ProgressFormatter, DocumentFormatter
+from .runner import Runner, ProgressFormatter, DocumentFormatter, LongFormatter
 import unittest
 import testslide.dsl
 from .strict_mock import StrictMock
@@ -154,6 +154,8 @@ class Cli(object):
         "progress": ProgressFormatter,
         "d": DocumentFormatter,
         "documentation": DocumentFormatter,
+        "l": LongFormatter,
+        "long": LongFormatter,
     }
 
     @staticmethod


### PR DESCRIPTION
Add `--format long` option to have this one-liner view of test results:

![image](https://user-images.githubusercontent.com/1386232/78827693-6b1bbc80-79db-11ea-9662-1285b7757b3b.png)
