### PR TITLE
Add DSL debugging option

### DIFF
--- a/docs/test_runner/index.rst
+++ b/docs/test_runner/index.rst
@@ -142,12 +142,15 @@ And this test will be skipped:
     Successful: 3
     Skipped: 1
 
-Stack Trace Simplification
---------------------------
+Path Simplification
+-------------------
 
-Stack traces can be hard to read. By default, TestSlide trims the working directory from file names on stack traces, simplifying the output. You can tweak this behavior with ``--trim-strace-path-prefix``.
+The option ``--trim-path-prefix`` selects a path prefix to remove from stack traces and error messages. This makes parsing error messages easier. It defaults to the working directory, so there's seldom need to tweak it.
 
-Also, stack trace lines that are from TestSlide's code base are hidden, as they are only useful when debugging TestSlide itself. You can see them if you wish, by using ``--show-testslide-stack-trace``.
+Internal Stack Trace
+--------------------
+
+By default, stack trace lines that are from TestSlide's code base are hidden, as they are only useful when debugging TestSlide itself. You can see them if you wish, by using ``--show-testslide-stack-trace``.
 
 Shuffled Execution
 ------------------

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -508,9 +508,9 @@ class TestCliDocumentationFormatter(TestCliBase):
             ),
         )
 
-    def test_empty_trim_strace_path_prefix(self):
+    def test_empty_trim_path_prefix(self):
         """
-        Trims nothing if '' passed to --trim-stack-trace-path-prefix.
+        Trims nothing if '' passed to --trim-path-prefix.
         """
         self.argv.append("--trim-path-prefix")
         self.argv.append("")

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -485,9 +485,9 @@ class TestCliDocumentationFormatter(TestCliBase):
             ),
         )
 
-    def test_default_trim_stack_trace_path_prefix(self):
+    def test_default_trim_path_prefix(self):
         """
-        Default value for --trim-stack-trace-path-prefix trims path shared with
+        Default value for --trim-path-prefix trims path shared with
         testslide itself.
         """
         self.run_testslide(
@@ -495,11 +495,11 @@ class TestCliDocumentationFormatter(TestCliBase):
             expected_in_stdout=('File "tests/sample_tests.py", line'),
         )
 
-    def test_nonempty_trim_stack_trace_path_prefix(self):
+    def test_nonempty_trim_path_prefix(self):
         """
-        Trims prefix passed to --trim-stack-trace-path-prefix.
+        Trims prefix passed to --trim-path-prefix.
         """
-        self.argv.append("--trim-stack-trace-path-prefix")
+        self.argv.append("--trim-path-prefix")
         self.argv.append(os.path.dirname(self.SAMPLE_TESTS_PATH) + "/")
         self.run_testslide(
             expected_return_code=1,
@@ -512,7 +512,7 @@ class TestCliDocumentationFormatter(TestCliBase):
         """
         Trims nothing if '' passed to --trim-stack-trace-path-prefix.
         """
-        self.argv.append("--trim-stack-trace-path-prefix")
+        self.argv.append("--trim-path-prefix")
         self.argv.append("")
         self.run_testslide(
             expected_return_code=1,

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -519,6 +519,31 @@ class TestCliDocumentationFormatter(TestCliBase):
             expected_in_stdout=('File "' + self.SAMPLE_TESTS_PATH + '", line'),
         )
 
+    def test_dsl_debug(self):
+        self.argv.append("--dsl-debug")
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context\n"
+                "  example: passing_example @ tests/sample_tests.py:34\n"
+                "  passing example: PASS\n"
+                "  example: failing_example @ tests/sample_tests.py:38\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "  example: focused_example @ tests/sample_tests.py:43\n"
+                "  *focused example: PASS\n"
+                "  skipped example: SKIP\n"
+                "  example: unittest_SkipTest @ tests/sample_tests.py:51\n"
+                "  unittest SkipTest: SKIP\n"
+                "  nested context\n"
+                "    example: passing_nested_example @ tests/sample_tests.py:58\n"
+                "    passing nested example: PASS\n"
+                "tests.sample_tests.SampleTestCase\n"
+                "  test_failing: AssertionError: \n"
+                "  test_passing: PASS\n"
+                "  test_skipped: SKIP\n"
+            ),
+        )
+
 
 class TestCliProgressFormatter(TestCliBase):
     def setUp(self):
@@ -544,6 +569,29 @@ class TestCliProgressFormatter(TestCliBase):
                 + self.green(".")
                 + self.yellow("S")
                 + "\r\n"
+            ),
+        )
+
+    def test_dsl_debug(self):
+        self.argv.append("--dsl-debug")
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "\n"
+                "example: passing_example @ tests/sample_tests.py:34\n"
+                ".\n"
+                "example: failing_example @ tests/sample_tests.py:38\n"
+                "F\n"
+                "example: focused_example @ tests/sample_tests.py:43\n"
+                ".\n"
+                "S\n"
+                "example: unittest_SkipTest @ tests/sample_tests.py:51\n"
+                "S\n"
+                "example: passing_nested_example @ tests/sample_tests.py:58\n"
+                ".\n"
+                "F\n"
+                ".\n"
+                "S\n"
             ),
         )
 
@@ -653,5 +701,36 @@ class TestCliLongFormatter(TestCliBase):
                 "tests.sample_tests.SampleTestCase: test_passing: PASS\n"
                 "tests.sample_tests.SampleTestCase: test_skipped: SKIP\n"
                 # TODO add remaining bits of the output (using regexes)
+            ),
+        )
+
+    def test_dsl_debug(self):
+        self.argv.append("--dsl-debug")
+        self.run_testslide(
+            expected_return_code=1,
+            expected_stdout_startswith=(
+                "top context: \n"
+                "  example: passing_example @ tests/sample_tests.py:34\n"
+                "  passing example: PASS\n"
+                "top context: \n"
+                "  example: failing_example @ tests/sample_tests.py:38\n"
+                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "top context: \n"
+                "  example: focused_example @ tests/sample_tests.py:43\n"
+                "  *focused example: PASS\n"
+                "top context: \n"
+                "  skipped example: SKIP\n"
+                "top context: \n"
+                "  example: unittest_SkipTest @ tests/sample_tests.py:51\n"
+                "  unittest SkipTest: SKIP\n"
+                "top context, nested context: \n"
+                "  example: passing_nested_example @ tests/sample_tests.py:58\n"
+                "  passing nested example: PASS\n"
+                "tests.sample_tests.SampleTestCase: \n"
+                "  test_failing: AssertionError: \n"
+                "tests.sample_tests.SampleTestCase: \n"
+                "  test_passing: PASS\n"
+                "tests.sample_tests.SampleTestCase: \n"
+                "  test_skipped: SKIP\n"
             ),
         )

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -10,7 +10,8 @@ import time
 
 from unittest.mock import Mock, call, patch
 
-from testslide import Context, AggregatedExceptions, SlowCallback, reset
+from testslide import Context, AggregatedExceptions, SlowCallback, reset, _ExampleRunner
+from testslide.runner import QuietFormatter
 from testslide.dsl import context, xcontext, fcontext
 import os
 import subprocess
@@ -96,17 +97,20 @@ class TestDSLBase(unittest.TestCase):
     def setUp(self):
         reset()
 
+    def run_example(self, exapmle):
+        _ExampleRunner(exapmle, QuietFormatter()).run()
+
     def run_all_examples(self):
         for each_context in Context.all_top_level_contexts:
             for example in each_context.all_examples:
-                example()
+                self.run_example(example)
 
     def run_first_context_first_example(self):
-        Context.all_top_level_contexts[0].all_examples[0]()
+        self.run_example(Context.all_top_level_contexts[0].all_examples[0])
 
     def run_first_context_all_examples(self):
         for example in Context.all_top_level_contexts[0].all_examples:
-            example()
+            self.run_example(example)
 
     def _print_context_hierarchy(self, contexts=None, indent=""):
         if contexts is None:
@@ -1922,8 +1926,8 @@ class TestPatchAttributeIntegration(TestDSLBase):
             for example in all_top_level_context.all_examples:
                 examples[example.name] = example
 
-        examples["can patch attribute"]()
-        examples["unpatching works"]()
+        self.run_example(examples["can patch attribute"])
+        self.run_example(examples["unpatching works"])
 
 
 class TestMockCallableIntegration(TestDSLBase):
@@ -1955,10 +1959,10 @@ class TestMockCallableIntegration(TestDSLBase):
             for example in all_top_level_context.all_examples:
                 examples[example.name] = example
 
-        examples["expect pass"]()
+        self.run_example(examples["expect pass"])
 
         with self.assertRaisesRegex(AssertionError, "calls did not match assertion"):
-            examples["expect fail"]()
+            self.run_example(examples["expect fail"])
 
 
 class TestMockAsyncCallableIntegration(TestDSLBase):
@@ -1995,10 +1999,10 @@ class TestMockAsyncCallableIntegration(TestDSLBase):
             for example in all_top_level_context.all_examples:
                 examples[example.name] = example
 
-        examples["expect pass"]()
+        self.run_example(examples["expect pass"])
 
         with self.assertRaisesRegex(AssertionError, "calls did not match assertion"):
-            examples["expect fail"]()
+            self.run_example(examples["expect fail"])
 
 
 class TestMockConstructorIntegration(TestDSLBase):
@@ -2030,7 +2034,7 @@ class TestMockConstructorIntegration(TestDSLBase):
             for example in all_top_level_context.all_examples:
                 examples[example.name] = example
 
-        examples["expect pass"]()
+        self.run_example(examples["expect pass"])
 
         with self.assertRaisesRegex(AssertionError, "calls did not match assertion"):
-            examples["expect fail"]()
+            self.run_example(examples["expect fail"])

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -5,14 +5,14 @@
 
 from contextlib import contextmanager
 
-import sys
-import asyncio.log
-import unittest
-import contextlib
-import re
-import types
 import asyncio
+import asyncio.log
+import contextlib
 import inspect
+import re
+import sys
+import types
+import unittest
 import warnings
 
 import testslide.mock_callable
@@ -88,8 +88,9 @@ class _ContextData(object):
 
         testslide.mock_callable.register_assertion = register_assertion
 
-    def __init__(self, example):
+    def __init__(self, example, formatter):
         self._example = example
+        self._formatter = formatter
         self._context = example.context
         self._after_functions = []
         self._test_case = unittest.TestCase()
@@ -122,6 +123,7 @@ class _ContextData(object):
                 raise ValueError(
                     f"Function can not be a coroutine function: {repr(attribute_code)}"
                 )
+            self._formatter.dsl_memoize(self._example, attribute_code)
             self.__dict__[name] = attribute_code(self)
 
         try:
@@ -217,8 +219,10 @@ class SlowCallback(Exception):
 
 
 class _ExampleRunner:
-    def __init__(self, example):
+    def __init__(self, example, formatter):
         self.example = example
+        self.formatter = formatter
+        self.trim_path_prefix = self.formatter.trim_path_prefix  # FIMXE
 
     @staticmethod
     async def _fail_if_not_coroutine_function(func, *args, **kwargs):
@@ -246,9 +250,16 @@ class _ExampleRunner:
             aggregated_exceptions = AggregatedExceptions()
             with aggregated_exceptions.catch():
                 for before_code in self.example.context.all_before_functions:
+                    if hasattr(before_code, "_memoize_before_code"):
+                        self.formatter.dsl_memoize_before(
+                            self.example, before_code._memoize_before_code
+                        )
+                    else:
+                        self.formatter.dsl_before(self.example, before_code)
                     await self._fail_if_not_coroutine_function(
                         before_code, context_data
                     )
+                self.formatter.dsl_example(self.example, self.example.code)
                 await self._fail_if_not_coroutine_function(
                     self.example.code, context_data
                 )
@@ -258,6 +269,7 @@ class _ExampleRunner:
             after_functions.extend(context_data._after_functions)
             for after_code in reversed(after_functions):
                 with aggregated_exceptions.catch():
+                    self.formatter.dsl_after(self.example, after_code)
                     await self._fail_if_not_coroutine_function(after_code, context_data)
             aggregated_exceptions.raise_correct_exception()
             return
@@ -271,6 +283,7 @@ class _ExampleRunner:
                 context_data, around_functions
             )
 
+        self.formatter.dsl_around(self.example, around_code)
         await self._fail_if_not_coroutine_function(
             around_code, context_data, async_wrapped
         )
@@ -373,7 +386,14 @@ class _ExampleRunner:
             aggregated_exceptions = AggregatedExceptions()
             with aggregated_exceptions.catch():
                 for before_code in self.example.context.all_before_functions:
+                    if hasattr(before_code, "_memoize_before_code"):
+                        self.formatter.dsl_memoize_before(
+                            self.example, before_code._memoize_before_code
+                        )
+                    else:
+                        self.formatter.dsl_before(self.example, before_code)
                     self._fail_if_coroutine_function(before_code, context_data)
+                self.formatter.dsl_example(self.example, self.example.code)
                 self._fail_if_coroutine_function(self.example.code, context_data)
             after_functions = []
             after_functions.extend(context_data._mock_callable_after_functions)
@@ -381,6 +401,7 @@ class _ExampleRunner:
             after_functions.extend(context_data._after_functions)
             for after_code in reversed(after_functions):
                 with aggregated_exceptions.catch():
+                    self.formatter.dsl_after(self.example, after_code)
                     self._fail_if_coroutine_function(after_code, context_data)
             aggregated_exceptions.raise_correct_exception()
             return
@@ -392,6 +413,7 @@ class _ExampleRunner:
             wrapped_called.append(True)
             self._sync_run_all_hooks_and_example(context_data, around_functions)
 
+        self.formatter.dsl_around(self.example, around_code)
         self._fail_if_coroutine_function(around_code, context_data, wrapped)
 
         if not wrapped_called:
@@ -405,7 +427,7 @@ class _ExampleRunner:
         try:
             if self.example.skip:
                 raise Skip()
-            context_data = _ContextData(self.example)
+            context_data = _ContextData(self.example, self.formatter)
             if self.example.is_async:
                 self._async_run_all_hooks_and_example(context_data)
             else:
@@ -450,12 +472,6 @@ class Example(object):
         True if the example of its context is marked to be focused.
         """
         return any([self.context.focus, self.__dict__["focus"]])
-
-    def __call__(self):
-        """
-        Run the example, including all around, before and after hooks.
-        """
-        _ExampleRunner(self).run()
 
     def __str__(self):
         return self.name
@@ -762,6 +778,7 @@ class Context(object):
                     ]
                     context_data.__dict__[name] = await code(context_data)
 
+                async_materialize_attribute._memoize_before_code = memoizable_code
                 self.before_functions.append(async_materialize_attribute)
             else:
 
@@ -771,6 +788,7 @@ class Context(object):
                     ]
                     context_data.__dict__[name] = code(context_data)
 
+                materialize_attribute._memoize_before_code = memoizable_code
                 self.before_functions.append(materialize_attribute)
 
     def add_shared_context(self, name, shared_context_code):

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -222,7 +222,7 @@ class _ExampleRunner:
     def __init__(self, example, formatter):
         self.example = example
         self.formatter = formatter
-        self.trim_path_prefix = self.formatter.trim_path_prefix  # FIMXE
+        self.trim_path_prefix = self.formatter.trim_path_prefix
 
     @staticmethod
     async def _fail_if_not_coroutine_function(func, *args, **kwargs):

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -227,6 +227,14 @@ class Cli(object):
             help="Suppress output (stdout and stderr) of tested code",
         )
         parser.add_argument(
+            "--dsl-debug",
+            action="store_true",
+            help=(
+                "Print debugging information during execution of TestSlide's "
+                "DSL tests."
+            ),
+        )
+        parser.add_argument(
             "--trim-path-prefix",
             nargs=1,
             type=str,
@@ -336,6 +344,7 @@ class Cli(object):
             parsed_args.exclude_regex[0] if parsed_args.exclude_regex else None
         )
         config.quiet = parsed_args.quiet
+        config.dsl_debug = parsed_args.dsl_debug
         if self._modules:
             config.import_module_names = self._modules
         else:
@@ -364,6 +373,7 @@ class Cli(object):
                 import_secs=import_secs,
                 trim_path_prefix=config.trim_path_prefix,
                 show_testslide_stack_trace=config.show_testslide_stack_trace,
+                dsl_debug=config.dsl_debug,
             )
             StrictMock.TRIM_PATH_PREFIX = config.trim_path_prefix
             if config.list:

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -227,13 +227,13 @@ class Cli(object):
             help="Suppress output (stdout and stderr) of tested code",
         )
         parser.add_argument(
-            "--trim-stack-trace-path-prefix",
+            "--trim-path-prefix",
             nargs=1,
             type=str,
-            default=[self._default_trim_stack_trace_path_prefix],
+            default=[self._default_trim_path_prefix],
             help=(
-                "Remove the specified prefix from stack trace paths in the output. "
-                "Default: {}".format(repr(self._default_trim_stack_trace_path_prefix))
+                "Remove the specified prefix from paths in some of the output. "
+                "Default: {}".format(repr(self._default_trim_path_prefix))
             ),
         )
         parser.add_argument(
@@ -268,11 +268,11 @@ class Cli(object):
             )
         return parser
 
-    def __init__(self, args, default_trim_stack_trace_path_prefix=None, modules=None):
+    def __init__(self, args, default_trim_path_prefix=None, modules=None):
         self.args = args
-        self._default_trim_stack_trace_path_prefix = (
-            default_trim_stack_trace_path_prefix
-            if default_trim_stack_trace_path_prefix
+        self._default_trim_path_prefix = (
+            default_trim_path_prefix
+            if default_trim_path_prefix
             else os.getcwd() + os.sep
         )
         self.parser = self._build_parser(disable_test_files=bool(modules))
@@ -318,9 +318,7 @@ class Cli(object):
 
         config.format = parsed_args.format
         config.force_color = parsed_args.force_color
-        config.trim_stack_trace_path_prefix = parsed_args.trim_stack_trace_path_prefix[
-            0
-        ]
+        config.trim_path_prefix = parsed_args.trim_path_prefix[0]
         config.show_testslide_stack_trace = parsed_args.show_testslide_stack_trace
         config.shuffle = parsed_args.shuffle
         config.list = parsed_args.list
@@ -364,10 +362,10 @@ class Cli(object):
             formatter = self.FORMAT_NAME_TO_FORMATTER_CLASS[config.format](
                 force_color=config.force_color,
                 import_secs=import_secs,
-                trim_stack_trace_path_prefix=config.trim_stack_trace_path_prefix,
+                trim_path_prefix=config.trim_path_prefix,
                 show_testslide_stack_trace=config.show_testslide_stack_trace,
             )
-            StrictMock.TRIM_PATH_PREFIX = config.trim_stack_trace_path_prefix
+            StrictMock.TRIM_PATH_PREFIX = config.trim_path_prefix
             if config.list:
                 formatter.discovery_start()
                 for context in Context.all_top_level_contexts:

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -25,13 +25,13 @@ class Formatter(object):
         self,
         force_color=False,
         import_secs=None,
-        trim_stack_trace_path_prefix=None,
+        trim_path_prefix=None,
         show_testslide_stack_trace=False,
     ):
         self.force_color = force_color
         self.import_secs = import_secs
         self._import_secs_warn = True
-        self.trim_stack_trace_path_prefix = trim_stack_trace_path_prefix
+        self.trim_path_prefix = trim_path_prefix
         self.show_testslide_stack_trace = show_testslide_stack_trace
         self.current_hierarchy = []
         self.results = {"success": [], "fail": [], "skip": []}
@@ -241,8 +241,8 @@ class DocumentFormatter(Formatter):
                     os.path.dirname(__file__)
                 ):
                     continue
-                if self.trim_stack_trace_path_prefix:
-                    split = path.split(self.trim_stack_trace_path_prefix)
+                if self.trim_path_prefix:
+                    split = path.split(self.trim_path_prefix)
                     if len(split) == 2 and not split[0]:
                         path = split[1]
                 self.print_cyan(
@@ -357,8 +357,8 @@ class LongFormatter(Formatter):
                     os.path.dirname(__file__)
                 ):
                     continue
-                if self.trim_stack_trace_path_prefix:
-                    split = path.split(self.trim_stack_trace_path_prefix)
+                if self.trim_path_prefix:
+                    split = path.split(self.trim_path_prefix)
                     if len(split) == 2 and not split[0]:
                         path = split[1]
                 self.print_cyan(


### PR DESCRIPTION
Adds `--dsl-debug` that makes it show when each of the DSL elements that the user defined is called:

- example
- before
- after
- around
- memoize
- memoize_before
- function

![image](https://user-images.githubusercontent.com/1386232/78922499-8a275680-7a8e-11ea-96ed-d4e5ba5086c1.png)

This should facilitate development and debugging on complex scenarios.

Closes #89.