### PR TITLE
Fix *args typing validation

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -43,6 +43,15 @@ def _validate_callable_arg_types(context):
                 False, object.__new__, (1, 2, 3), {"four": 5, "six": 6}
             )
 
+        @context.example
+        def args_as_starargs(self):
+            target = sample_module.SomeClass()
+            args = ("d", "x", "ddd")
+            kwargs = {"a": False, "b": 2, "c": None}
+            testslide.lib._validate_callable_arg_types(
+                False, target.instance_method_with_star_args, args, kwargs
+            )
+
         @context.example("testslide.StrictMock with valid template")
         def testslide_StrictMock_with_valid_template(self):
             strict_mock = StrictMock(template=str)

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -11,14 +11,14 @@ from testslide import StrictMock
 import unittest.mock
 
 
-@context("_validate_function_signature")
-def _validate_function_signature(context):
+@context("_validate_callable_arg_types")
+def _validate_callable_arg_types(context):
     @context.sub_context
     def valid_types(context):
         @context.function
         def assert_passes(self, *args, **kwargs):
-            testslide.lib._validate_function_signature(
-                sample_module.test_function, args, kwargs
+            testslide.lib._validate_callable_arg_types(
+                False, sample_module.test_function, args, kwargs
             )
 
         @context.example
@@ -39,8 +39,8 @@ def _validate_function_signature(context):
 
         @context.example
         def varargs_and_varkwargs(self):
-            testslide.lib._validate_function_signature(
-                object.__new__, (1, 2, 3), {"four": 5, "six": 6}
+            testslide.lib._validate_callable_arg_types(
+                False, object.__new__, (1, 2, 3), {"four": 5, "six": 6}
             )
 
         @context.example("testslide.StrictMock with valid template")
@@ -110,8 +110,8 @@ def _validate_function_signature(context):
             with self.assertRaisesRegex(
                 TypeError, "Call with incompatible argument types"
             ):
-                testslide.lib._validate_function_signature(
-                    sample_module.test_function, args, kwargs
+                testslide.lib._validate_callable_arg_types(
+                    False, sample_module.test_function, args, kwargs
                 )
 
         @context.example
@@ -126,8 +126,8 @@ def _validate_function_signature(context):
                     "  'kwarg2': type of kwarg2 must be str; got int instead"
                 ),
             ):
-                testslide.lib._validate_function_signature(
-                    sample_module.test_function, (1, 2, 3, 4), {}
+                testslide.lib._validate_callable_arg_types(
+                    False, sample_module.test_function, (1, 2, 3, 4), {}
                 )
 
         @context.example

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -91,11 +91,11 @@ def _validate_callable_arg_types(context):
             def with_typevar(lolo: TypeVar("T")) -> None:
                 pass
 
-            testslide.lib._validate_function_signature(
-                with_typevar, args=["arg1"], kwargs={}
+            testslide.lib._validate_callable_arg_types(
+                False, with_typevar, args=["arg1"], kwargs={}
             )
-            testslide.lib._validate_function_signature(
-                with_typevar, args=[], kwargs={"arg1": "arg1"}
+            testslide.lib._validate_callable_arg_types(
+                False, with_typevar, args=[], kwargs={"arg1": "arg1"}
             )
 
         @context.example("Nested TypeVar")
@@ -105,11 +105,11 @@ def _validate_callable_arg_types(context):
             def with_typevar(arg1: Type[TypeVar("T")]) -> None:
                 pass
 
-            testslide.lib._validate_function_signature(
-                with_typevar, args=["arg1"], kwargs={}
+            testslide.lib._validate_callable_arg_types(
+                False, with_typevar, args=["arg1"], kwargs={}
             )
-            testslide.lib._validate_function_signature(
-                with_typevar, args=[], kwargs={"arg1": "arg1"}
+            testslide.lib._validate_callable_arg_types(
+                False, with_typevar, args=[], kwargs={"arg1": "arg1"}
             )
 
     @context.sub_context

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
+
 attribute = "value"
 
 
@@ -17,6 +19,11 @@ class SomeClass:
 
     def method(self):
         pass
+
+    def instance_method_with_star_args(
+        self, first, *args: str, a: bool, b: int, c: Optional[int], d: int = 3
+    ) -> int:
+        return 3
 
 
 class TargetStr(object):

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -9,7 +9,7 @@ import functools
 from typing import List, Callable, Tuple, Any, Dict
 import testslide
 from testslide.strict_mock import StrictMock
-from testslide.lib import _wrap_signature_validation, _validate_return_type
+from testslide.lib import _wrap_signature_and_type_validation, _validate_return_type
 from .patch import _patch, _is_instance_method
 from .lib import _bail_if_private
 
@@ -621,7 +621,7 @@ class _MockCallableDSL(object):
             original_callable = getattr(self._target, self._method)
 
         if not isinstance(self._target, StrictMock):
-            new_value = _wrap_signature_validation(
+            new_value = _wrap_signature_and_type_validation(
                 new_value, self._target, self._method, self.type_validation
             )
 

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -578,7 +578,7 @@ class StrictMock(object):
                     if not callable(value):
                         raise NonCallableValue(self, name)
                     if self.__dict__["_signature_validation"]:
-                        signature_validation_wrapper = testslide.lib._wrap_signature_validation(
+                        signature_validation_wrapper = testslide.lib._wrap_signature_and_type_validation(
                             value,
                             self._template,
                             name,


### PR DESCRIPTION
We were not correctly handling this case that is contained in the added test.

Along the way:

- I separated logic regarding signature validation & type validation.
- Changed methods to have proper names.
- Got rid of the ugly dependency on unittest's `_must_skip` private method.
  - Decoupled this logic from both signature & type validation.
  - The new method `_skip_first_arg` must be called from inside `_wrap_signature_and_type_validation` because if it is done from other functions that need its return, the patch will already be in place, and it'll not work.

Credits to @deathowl for helping with all the debugging and ground work prior to this PR.