### PR TITLE
[signature validation] Skip TypeVar signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/*.pyc
 **/__pycache__/
+.*.sw?
 .coverage
 .coverage.*.*.*
 .mypy_cache/

--- a/docs/patching/mock_callable/index.rst
+++ b/docs/patching/mock_callable/index.rst
@@ -455,6 +455,12 @@ Return Value Type
               # TypeError: type of return must be int; got str instead
               some_class_instance.one()
 
+Limitations
+^^^^^^^^^^^
+
+Currently `TypeVar` annotations are not being checked for.
+
+
 Test Framework Integration
 --------------------------
 

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Type, TypeVar
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 import testslide.lib
 from . import sample_module
@@ -73,6 +74,34 @@ def _validate_function_signature(context):
             self.assert_passes("arg1", mock, kwarg1="kwarg1", kwarg2="kwarg2")
             self.assert_passes("arg1", "arg2", kwarg1=mock, kwarg2="kwarg2")
             self.assert_passes("arg1", "arg2", kwarg1="kwarg1", kwarg2=mock)
+
+        @context.example("TypeVar")
+        def typevar(self):
+            """We currently can't enforce typevars"""
+
+            def with_typevar(lolo: TypeVar("T")) -> None:
+                pass
+
+            testslide.lib._validate_function_signature(
+                with_typevar, args=["arg1"], kwargs={}
+            )
+            testslide.lib._validate_function_signature(
+                with_typevar, args=[], kwargs={"arg1": "arg1"}
+            )
+
+        @context.example("Nested TypeVar")
+        def nested_typevar(self):
+            """We currently can't enforce typevars"""
+
+            def with_typevar(arg1: Type[TypeVar("T")]) -> None:
+                pass
+
+            testslide.lib._validate_function_signature(
+                with_typevar, args=["arg1"], kwargs={}
+            )
+            testslide.lib._validate_function_signature(
+                with_typevar, args=[], kwargs={"arg1": "arg1"}
+            )
 
     @context.sub_context
     def invalid_types(context):

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -82,17 +82,35 @@ def _validate_function_signature(
                 expected_type = argspec.annotations.get(argname)
                 if not expected_type:
                     continue
+
+                if "~" in str(expected_type):
+                    # this means that we have a TypeVar type, and those require
+                    # checking all the types of all the params as a whole, but we
+                    # don't have a good way of getting right now
+                    # TODO: #165
+                    continue
+
                 _validate_argument_type(expected_type, argname, args[idx])
             except TypeError as type_error:
                 type_errors.append(f"{repr(argname)}: {type_error}")
+
     for argname, value in kwargs.items():
         try:
             expected_type = argspec.annotations.get(argname)
             if not expected_type:
                 continue
+
+            if "~" in str(expected_type):
+                # this means that we have a TypeVar type, and those require
+                # checking all the types of all the params as a whole, but we
+                # don't have a good way of getting right now
+                # TODO: #165
+                continue
+
             _validate_argument_type(expected_type, argname, value)
         except TypeError as type_error:
             type_errors.append(f"{repr(argname)}: {type_error}")
+
     if type_errors:
         raise TypeError(
             "Call with incompatible argument types:\n  " + "\n  ".join(type_errors)


### PR DESCRIPTION
In order to be able to check TypeVars we have to be able to check the
whole signature type hints at the same time (as typevars are dynamically
defined).

This just skips them for now to avoid failing the type checks.

It's using the `str` method of the type hint to traverse the type
definition and see if there are any typevars (prefixed with `~`), it's a
hacky way, but quite effective until we have the need to traverse the
type hint ourselves, at that point we can use that instead.