### PR TITLE
Improve Makefile mechanics & output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ python:
   - 3.6
   - 3.7
   - 3.8
-install:
-  - make install_deps
 script:
   TESTSLIDE_FORMAT="progress" UNITTEST_VERBOSE="" make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
   - 3.7
   - 3.8
 script:
-  TESTSLIDE_FORMAT="progress" UNITTEST_VERBOSE="" make travis
+  TESTSLIDE_FORMAT=progress UNITTEST_VERBOSE=1 make travis V=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Generally speaking:
 
 - Install a supported Python version (see `.travis.yml`) (suggestion: use [pyenv](https://github.com/pyenv/pyenv)).
 - Install the dependencies: `make install_build_deps`.
-- Run the tests: `make`.
+- Run the tests: `make` (or `make V=1` for verbose output).
 
 Here's a quick cookbook on how to have a Python installation working using Docker:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ We actively welcome your pull requests.
 
 Generally speaking:
 
-- Install a supported Python version (see `.travis.yml`).
-- Install the dependencies: `make install_deps`.
+- Install a supported Python version (see `.travis.yml`) (suggestion: use [pyenv](https://github.com/pyenv/pyenv)).
+- Install the dependencies: `make install_build_deps`.
 - Run the tests: `make`.
 
-Here is a reference cookbook on how to achieve that using Docker and [pyenv](https://github.com/pyenv/pyenv):
+Here's a quick cookbook on how to have a Python installation working using Docker:
 
 - Install [Docker CE](https://docs.docker.com/install/).
 - Clone the repo: `git clone https://github.com/facebookincubator/TestSlide.git`.
@@ -43,8 +43,6 @@ eval "$(pyenv virtualenv-init -)"
 - Do `exec bash -i`.
 - Install Python: `pyenv install 3.7.3`.
 - Enable the installed version `pyenv shell 3.7.3`.
-- Install the dependencies: `make install_deps`.
-- Run the tests: `make`.
 
 ## Contributor License Agreement ("CLA")
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 ##
 
 .PHONY: all
-all: coverage_report
+all: tests coverage_report docs sdist
 
 # .PHONY does not work for implicit rules, so we FORCE them
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -3,45 +3,89 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+##
+## Variables
+##
+
 TESTSLIDE_FORMAT?=documentation
 UNITTEST_VERBOSE?=--verbose
+TESTS_SRCS = tests
+SRCS = testslide
+ALL_SRCS = $(TESTS_SRCS) $(SRCS)
+
+##
+## Default
+##
 
 .PHONY: all
-all: test
+all: all_tests
 
-.PHONY: coveralls
-coveralls:
-	coveralls
+##
+## Rules
+##
 
-.PHONY: travis
-travis: test install_local coveralls
+%_unittest.py: FORCE
+	coverage run -m unittest $(UNITTEST_VERBOSE) --failfast $@
 
-.PHONY: install_deps
-install_deps:
-	pip install -e .[test,build]
+%_testslide.py: FORCE
+	coverage run -m testslide.cli --format $(TESTSLIDE_FORMAT) --show-testslide-stack-trace --fail-fast --fail-if-focused $@
+
+# .PHONY does not work for implicit rules, so we FORCE them
+FORCE:
+
+##
+## Docs
+##
+
+.PHONY: docs
+docs:
+	cd docs && make html
+
+.PHONY: docs_clean
+docs_clean:
+	rm -rf docs/_build/
+
+##
+## Tests
+##
+
+.PHONY: unittest_tests
+unittest_tests: $(TESTS_SRCS)/*_unittest.py
+
+.PHONY: testslide_tests
+testslide_tests: $(TESTS_SRCS)/*_testslide.py
+
+.PHONY: mypy
+mypy:
+	mypy testslide
 
 .PHONY: flake8
 flake8:
-	flake8 --select=F,C90 testslide/ tests/
+	flake8 --select=F,C90 $(ALL_SRCS)
 
 .PHONY: black_check
 black_check:
-	black --check testslide/ tests/
+	black --check $(ALL_SRCS)
+
+.PHONY: coverage_tests
+coverage_tests: unittest_tests testslide_tests
+
+.PHONY: all_tests
+all_tests: \
+	coverage_tests \
+	mypy \
+	flake8 \
+	black_check
+##
+## Coverage
+##
 
 .PHONY: coverage_erase
 coverage_erase:
 	coverage erase
 
-.PHONY: unittest_tests
-unittest_tests: coverage_erase
-	coverage run -m unittest discover $(UNITTEST_VERBOSE) --failfast -p '*_unittest.py'
-
-.PHONY: testslide_tests
-testslide_tests: coverage_erase
-	coverage run -m testslide.cli --format $(TESTSLIDE_FORMAT) --show-testslide-stack-trace --fail-fast --fail-if-focused tests/*_testslide.py
-
 .PHONY: coverage_combine
-coverage_combine: unittest_tests testslide_tests
+coverage_combine: coverage_erase coverage_tests
 	coverage combine
 
 .PHONY: coverage_report
@@ -52,27 +96,49 @@ coverage_report: coverage_combine
 coverage_html: coverage_combine
 	coverage html
 
-.PHONY: docs
-docs:
-	cd docs && make html
+.PHONY: coverage_html_clean
+coverage_html_clean:
+	rm -rf htmlcov/
+
+.PHONY: coveralls
+coveralls: coverage_combine
+	coveralls
+
+##
+## Build
+##
+
+.PHONY: install_build_deps
+install_build_deps:
+	pip install -e .[test,build]
 
 .PHONY: sdist
 sdist:
 	python setup.py sdist
+
+.PHONY: sdist_clean
+sdist_clean:
+	rm -rf dist/ MANIFEST TestSlide.egg-info/
 
 .PHONY: install_local
 install_local:
 	pip install -e .
 	testslide --help
 
-.PHONY: mypy
-mypy:
-	mypy testslide
+.PHONY: travis
+travis: \
+	install_build_deps \
+	all_tests \
+	coverage_report \
+	coveralls \
+	docs \
+	sdist \
+	install_local
 
-.PHONY: test
-test: unittest_tests testslide_tests coverage_report flake8 mypy black_check docs sdist
+##
+## Clean
+##
 
 .PHONY: clean
-clean:
-	coverage erase
-	rm -rf dist/ MANIFEST TestSlide.egg-info/ */__pycache__/ */*.pyc docs/_build/ htmlcov/
+clean: sdist_clean docs_clean coverage_html_clean coverage_erase
+	rm -rf */__pycache__/ */*.pyc

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -15,6 +15,7 @@ from testslide.runner import QuietFormatter
 from testslide.dsl import context, xcontext, fcontext
 import os
 import subprocess
+from typing import List
 
 
 class SomeTestCase(unittest.TestCase):
@@ -22,7 +23,7 @@ class SomeTestCase(unittest.TestCase):
     Used to test TestSlide and unittest.TestCase integration.
     """
 
-    CALLS = []
+    CALLS: List[str] = []
 
     def setUp(self):
         self.CALLS.append("setUp")
@@ -53,7 +54,7 @@ class SomeTestCase2(unittest.TestCase):
     Used to test TestSlide and unittest.TestCase integration.
     """
 
-    CALLS = []
+    CALLS: List[str] = []
 
     def setUp(self):
         self.CALLS.append("setUp2")

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -52,7 +52,7 @@ class Target(TargetParent):
         super().__init__(p3_super=True)
 
         if message is not None:
-            args = [message] + list(args)
+            args = tuple([message] + list(args))
         super(Target, self).__init__(*args, **kwargs)
 
         self.dynamic_attr = "dynamic_attr"

--- a/util/run_silent_if_successful.py
+++ b/util/run_silent_if_successful.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import pty, sys, subprocess, os, threading
+
+
+master_pty_fd, slave_pty_fd = pty.openpty()
+read_data = []
+
+
+def master_pty_fd_reader():
+    while True:
+        try:
+            data = os.read(master_pty_fd, 1024)
+        except OSError:
+            return
+        else:
+            if data:
+                read_data.append(data)
+            else:
+                return
+
+
+master_pty_fd_reader_thread = threading.Thread(target=master_pty_fd_reader)
+
+master_pty_fd_reader_thread.start()
+
+completed_process = subprocess.run(
+    sys.argv[1:], stdin=subprocess.DEVNULL, stdout=slave_pty_fd, stderr=slave_pty_fd,
+)
+
+os.close(slave_pty_fd)
+
+master_pty_fd_reader_thread.join()
+
+if completed_process.returncode:
+    for data in read_data:
+        os.write(sys.stdout.fileno(), data)
+    sys.exit(completed_process.returncode)


### PR DESCRIPTION
Improve Makefile:

- Nicer slimmer output.
- Travis CI signal remains full verbose.
- Colored output works on fails.
- Fixed mypy not covering `tests/`.
- Moved `mock_async_callable` tests to its own file (as is).
- Making a test file now works: `make tests/cli_unittest.py`.

And finally, `make -j`:

- Before: 19.6s.
- Now: 9.0s.

# Quiet on success

![image](https://user-images.githubusercontent.com/1386232/79640442-8d56cc80-8189-11ea-977e-791d785abb80.png)

# Show output on failures

![image](https://user-images.githubusercontent.com/1386232/79640463-a8c1d780-8189-11ea-946d-62c6be49a090.png)

# Show output with `V=1`

![image](https://user-images.githubusercontent.com/1386232/79640482-bd05d480-8189-11ea-88f9-9435ca61d1db.png)
