### PR TITLE
Better handling of received signals

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,6 @@ parallel = True
 [report]
 precision = 2
 fail_under = 92.31
-include = testslide/*
+include = 
+	testslide/*
+	util/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ parallel = True
 
 [report]
 precision = 2
-fail_under = 92.31
+fail_under = 91.90
 include = 
 	testslide/*
 	util/*

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ TERM_NONE := $(shell tput sgr0)
 # Verbose output: make V=1
 V?=0
 ifeq ($(V),0)
-Q := @python util/run_silent_if_successful.py
+Q := @coverage run util/run_silent_if_successful.py
 else
 Q := 
 endif

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
 UNITTEST_ARGS := --verbose
 endif
 TESTS_SRCS = tests
-SRCS = testslide
+SRCS = testslide util
 ALL_SRCS = $(TESTS_SRCS) $(SRCS)
 TERM_BRIGHT := $(shell tput bold)
 TERM_NONE := $(shell tput sgr0)

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -402,8 +402,11 @@ class Cli(object):
 def main():
     if "" not in sys.path:
         sys.path.insert(0, "")
-    sys.exit(Cli(sys.argv[1:]).run())
-
+    try:
+        sys.exit(Cli(sys.argv[1:]).run())
+    except KeyboardInterrupt:
+        print("SIGINT received, exiting.", file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -408,5 +408,6 @@ def main():
         print("SIGINT received, exiting.", file=sys.stderr)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     main()

--- a/util/run_silent_if_successful.py
+++ b/util/run_silent_if_successful.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
-import pty, sys, subprocess, os, threading
+import os
+import pty
+import signal
+import subprocess
+import sys
+import threading
 
 
 master_pty_fd, slave_pty_fd = pty.openpty()
 read_data = []
+returncode = None
 
 
 def master_pty_fd_reader():
@@ -24,15 +30,17 @@ master_pty_fd_reader_thread = threading.Thread(target=master_pty_fd_reader)
 
 master_pty_fd_reader_thread.start()
 
-completed_process = subprocess.run(
+popen = subprocess.Popen(
     sys.argv[1:], stdin=subprocess.DEVNULL, stdout=slave_pty_fd, stderr=slave_pty_fd,
 )
+
+returncode = popen.wait()
 
 os.close(slave_pty_fd)
 
 master_pty_fd_reader_thread.join()
 
-if completed_process.returncode:
+if returncode:
     for data in read_data:
         os.write(sys.stdout.fileno(), data)
-    sys.exit(completed_process.returncode)
+    sys.exit(returncode)


### PR DESCRIPTION
Improve signal handling (specially ^C):

- `testslide` does not spit stack trace for ^C.
- `util/run_silent_if_successful.py`:
  - Forward received signals to subprocess and wait for it to terminate.
  - Handle file not found errors gracefully.
- Add `util/` to black, mypy & flake8.

Before:
![image](https://user-images.githubusercontent.com/1386232/79690085-8e066600-8250-11ea-869e-7315102064e6.png)
After:
![image](https://user-images.githubusercontent.com/1386232/79690092-99599180-8250-11ea-9d6c-c379905add32.png)

