### PR TITLE
Fix circular dependency on 'coverage' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ TERM_NONE := $(shell tput sgr0)
 # Verbose output: make V=1
 V?=0
 ifeq ($(V),0)
-Q := @coverage run util/run_silent_if_successful.py
+Q := @python util/run_silent_if_successful.py
 else
 Q := 
 endif


### PR DESCRIPTION
This seems to be a small regression introduced lately.

If you uninstall `coverage` and follow the contributing guideline you'll get:

```
pip uninstall coverage

make install_build_deps
INSTALL BUILD DEPS
/bin/sh: coverage: command not found
make: *** [install_build_deps] Error 127
```

Another option could be updating the `CONTRIBUTING.md` to require `pip install coverage`. 

And there are probably a thousand more options, let me know which one you prefer @fornellas.