### PR TITLE
improved error logging for return type error

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -6,6 +6,7 @@
 from typing import Type, TypeVar
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 import testslide.lib
+import testslide.mock_callable
 from . import sample_module
 from testslide import StrictMock
 import unittest.mock
@@ -87,16 +88,23 @@ def _validate_callable_arg_types(context):
 
     @context.example("Invalid return Type raises TypeError")
     def assert_raised_typeerror(self):
+        target_obj = sample_module.InvalidReturnType()
+
+        fake_runner = testslide.mock_callable._ReturnValueRunner(
+            target=target_obj,
+            method="invalid_return_type_function",
+            original_callable=target_obj.invalid_return_type_function,
+            value=target_obj.invalid_return_type_function(),
+        )
         with self.assertRaises(
             TypeError,
                 msg=(
-                "Call with incorrect return types at "
-                "/Users/jottosson/TestSlide/tests/sample_module.py:101:\n"
-                    "expected <class 'int'> got str"
+                    f"Call with incorrect return types, expected <class 'int'> got str.\n"
+                    f"Call initiated from object: {repr(target_obj)}"
             )
         ):
             testslide.lib._validate_return_type(
-                sample_module.invalid_return_type_function, "str"
+                fake_runner, "str"
             )
 
     @context.example("works with object.__new__")

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -85,6 +85,20 @@ def _validate_callable_arg_types(context):
                 self.skip_first_arg, self.callable_template, (1, 2, 3, 4), {}
             )
 
+    @context.example("Invalid return Type raises TypeError")
+    def assert_raised_typeerror(self):
+        with self.assertRaises(
+            TypeError,
+                msg=(
+                "Call with incorrect return types at "
+                "/Users/jottosson/TestSlide/tests/sample_module.py:101:\n"
+                    "expected <class 'int'> got str"
+            )
+        ):
+            testslide.lib._validate_return_type(
+                sample_module.invalid_return_type_function, "str"
+            )
+
     @context.example("works with object.__new__")
     def works_with_object_new(self):
         self.callable_template = object.__new__

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -105,6 +105,10 @@ def test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = "") -> s
     return "original response"
 
 
+def invalid_return_type_function() -> int:
+    return "string response"
+
+
 async def async_test_function(
     arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
 ) -> str:

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -128,3 +128,8 @@ TupleArgType = Dict[str, Tuple[str, int]]
 
 def test_tuple(arg: TupleArgType):
     pass
+
+
+class InvalidReturnType(object):
+    def invalid_return_type_function(self) -> int:
+        return "somereturnstring"

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -178,9 +178,20 @@ def _validate_return_type(template, value):
         argspec = inspect.getfullargspec(template)
     except TypeError:
         return
+    source_file = inspect.getsourcefile(template)
+    source_line = inspect.getsourcelines(template)
+
     expected_type = argspec.annotations.get("return")
     if expected_type:
-        _validate_argument_type(expected_type, "return", value)
+        try:
+            _validate_argument_type(expected_type, "return", value)
+        except TypeError:
+            error_msg = (
+                f"Call with incorrect return types at {source_file}:{source_line[1]}:\n"
+                f"expected {expected_type} got {value}")
+            raise TypeError(
+                error_msg
+            )
 
 
 ##

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -173,24 +173,22 @@ def _wrap_signature_and_type_validation(value, template, attr_name, type_validat
     return with_sig_and_type_validation
 
 
-def _validate_return_type(template, value):
+def _validate_return_type(runner, value):
     try:
-        argspec = inspect.getfullargspec(template)
+        argspec = inspect.getfullargspec(runner.original_callable)
     except TypeError:
         return
-    source_file = inspect.getsourcefile(template)
-    source_line = inspect.getsourcelines(template)
 
     expected_type = argspec.annotations.get("return")
     if expected_type:
         try:
             _validate_argument_type(expected_type, "return", value)
-        except TypeError:
-            error_msg = (
-                f"Call with incorrect return types at {source_file}:{source_line[1]}:\n"
-                f"expected {expected_type} got {value}")
-            raise TypeError(
-                error_msg
+
+        except ValueError:
+            target = runner.target
+            raise ValueError(
+                f"Call with incorrect return types, expected {expected_type} got {value}.\n"
+                f"Call initiated from object: {repr(target)}"
             )
 
 

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -462,12 +462,8 @@ class _CallableMock(object):
         return None
 
     def _validate_return_type(self, runner, value):
-        if (
-            self.type_validation
-            and runner.TYPE_VALIDATION
-            and runner.original_callable is not None
-        ):
-            _validate_return_type(runner.original_callable, value)
+        if runner.TYPE_VALIDATION and runner.original_callable is not None:
+            _validate_return_type(runner, value)
 
     def __call__(self, *args, **kwargs):
         runner = self._get_runner(*args, **kwargs)


### PR DESCRIPTION
Changed the logging for whenever there is a typing error on the return type it will log what file / line number the error happened to make it easier for the user to find the problem.

Closes #161.