### PR TITLE
Fix arguments validation logic

### DIFF
--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -123,9 +123,16 @@ def _validate_callable_arg_types(
 
 
 def _skip_first_arg(template, attr_name):
-    if not isinstance(template, type):
+
+    if inspect.ismodule(template):
         return False
-    for klass in template.__mro__:
+
+    if inspect.isclass(template):
+        mro = template.__mro__
+    else:
+        mro = template.__class__.__mro__
+
+    for klass in mro:
         if attr_name not in klass.__dict__:
             continue
         attr = klass.__dict__[attr_name]


### PR DESCRIPTION
It's a bit of a shitshow that we didn't catch these simple cases with our test suite!😕 

We should definitely integrate some of those and probably refactor a bit the tests...

```py
import sys
from testslide.dsl import context
from testslide import StrictMock


class T(object):
    def sync_instance_method(self, number: int, text: str):
        pass

    async def async_instance_method(self, number: int, text: str):
        pass


def module_sync_method(number: int, text: str):
    pass


@context
def top(context):
    @context.example
    def test_sync_instance_method(self):
        def sync_func(number, text):
            print(number, text)

        t = T()
        self.mock_callable(t, "sync_instance_method").with_implementation(sync_func)
        t.sync_instance_method(1, "t")

    @context.example
    async def test_async_instance_method(self):
        async def async_func(number, text):
            print(number, text)

        t = StrictMock(template=T)
        self.mock_async_callable(t, "async_instance_method").with_implementation(
            async_func
        )
        await t.async_instance_method(1, "t")

    @context.example
    def test_strict_mock_sync_instance_method(self):
        def sync_func(number, text):
            print(number, text)

        t = StrictMock(template=T)
        self.mock_callable(t, "sync_instance_method").with_implementation(sync_func)
        t.sync_instance_method(1, "t")

    @context.example
    def test_module_sync_method(self):
        def sync_func(number, text):
            print(number, text)

        current_module = sys.modules[__name__]
        self.mock_callable(current_module, "module_sync_method").with_implementation(
            sync_func
        )
        module_sync_method(1, "t")
```