### PR TITLE
[mock_callable] Do not load the context on inspect

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -12,6 +12,9 @@ from testslide import StrictMock
 import unittest.mock
 
 
+T = TypeVar("T")
+
+
 @context("_validate_callable_arg_types")
 def _validate_callable_arg_types(context):
     @context.memoize
@@ -163,7 +166,7 @@ def _validate_callable_arg_types(context):
             https://github.com/facebookincubator/TestSlide/issues/165
             """
 
-            def with_typevar(lolo: TypeVar("T")) -> None:
+            def with_typevar(lolo: T) -> None:
                 pass
 
             self.callable_template = with_typevar
@@ -177,7 +180,7 @@ def _validate_callable_arg_types(context):
             https://github.com/facebookincubator/TestSlide/issues/165
             """
 
-            def with_typevar(arg1: Type[TypeVar("T")]) -> None:
+            def with_typevar(arg1: Type[T]) -> None:
                 pass
 
             self.callable_template = with_typevar

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -1119,8 +1119,8 @@ def strict_mock(context):
                     async def default_raises_UndefinedAttribute(self):
                         with self.assertRaisesWithRegexMessage(
                             UndefinedAttribute,
-                            f"'__aiter__' is not set.\n"
-                            f"<StrictMock .+> must have a value set "
+                            "'__aiter__' is not set.\n"
+                            "<StrictMock .+> must have a value set "
                             "for this attribute if it is going to be accessed.",
                         ):
                             async for _ in self.strict_mock:
@@ -1151,8 +1151,8 @@ def strict_mock(context):
                     async def default_raises_UndefinedAttribute(self):
                         with self.assertRaisesWithRegexMessage(
                             UndefinedAttribute,
-                            f"'__aenter__' is not set.\n"
-                            f"<StrictMock .+> must have a value set "
+                            "'__aenter__' is not set.\n"
+                            "<StrictMock .+> must have a value set "
                             "for this attribute if it is going to be accessed.",
                         ):
                             async with self.strict_mock:

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -226,7 +226,7 @@ def _bail_if_private(candidate: str, allow_private: bool):
         and not (candidate.startswith("__") and candidate.endswith("__"))
     ):
         raise ValueError(
-            f"It's disencouraged to patch/mock private interfaces.\n"
+            "It's disencouraged to patch/mock private interfaces.\n"
             "This would result in way too coupled tests and implementation. "
             "Please consider using patterns like dependency injection instead. "
             "If you really need to do this use the allow_private=True argument."

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -16,7 +16,7 @@ from .lib import _bail_if_private
 
 def mock_callable(target, method, allow_private=False, type_validation=True):
     caller_frame = inspect.currentframe().f_back
-    caller_frame_info = inspect.getframeinfo(caller_frame)
+    caller_frame_info = inspect.getframeinfo(caller_frame, context=0)
     return _MockCallableDSL(
         target,
         method,
@@ -34,7 +34,7 @@ def mock_async_callable(
     type_validation=True,
 ):
     caller_frame = inspect.currentframe().f_back
-    caller_frame_info = inspect.getframeinfo(caller_frame)
+    caller_frame_info = inspect.getframeinfo(caller_frame, context=0)
     return _MockAsyncCallableDSL(
         target,
         method,


### PR DESCRIPTION
This speeds up considerably (from ~0.2ms to <0.01) the mocking when the
modules under test are many or the disk is slow as it skips having to
read the file to get the surrounding lines.