### PR TITLE
[global] don't load context when using getframeinfo

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -276,7 +276,9 @@ def _validate_return_type(context):
     @context.memoize
     def caller_frame_info(self):
         caller_frame = inspect.currentframe().f_back
-        caller_frame_info = inspect.getframeinfo(caller_frame)
+        # loading the context ends up reading files from disk and that might block
+        # the event loop, so we don't do it.
+        caller_frame_info = inspect.getframeinfo(caller_frame, context=0)
         return caller_frame_info
 
     @context.function

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -65,7 +65,9 @@ class _MockConstructorDSL(_MockCallableDSL):
     def __init__(self, target, method, cls, callable_mock=None, original_callable=None):
         self.cls = cls
         caller_frame = inspect.currentframe().f_back
-        caller_frame_info = inspect.getframeinfo(caller_frame)
+        # loading the context ends up reading files from disk and that might block
+        # the event loop, so we don't do it.
+        caller_frame_info = inspect.getframeinfo(caller_frame, context=0)
         super(_MockConstructorDSL, self).__init__(
             target,
             method,
@@ -328,7 +330,9 @@ def mock_constructor(target, class_name, allow_private=False, type_validation=Tr
             raise ValueError("Old style classes are not supported.")
 
         caller_frame = inspect.currentframe().f_back
-        caller_frame_info = inspect.getframeinfo(caller_frame)
+        # loading the context ends up reading files from disk and that might block
+        # the event loop, so we don't do it.
+        caller_frame_info = inspect.getframeinfo(caller_frame, context=0)
         callable_mock = _CallableMock(original_class, "__new__", caller_frame_info)
         mocked_class = _patch_and_return_mocked_class(
             target,

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -439,6 +439,8 @@ class StrictMock(object):
         # and that is really slow, this only retrieves the minimum, and does
         # not read the file contents.
         caller_frame = self._get_caller_frame(depth)
+        # loading the context ends up reading files from disk and that might block
+        # the event loop, so we don't do it.
         frameinfo = inspect.getframeinfo(caller_frame, context=0)
         filename = frameinfo.filename
         lineno = frameinfo.lineno
@@ -495,7 +497,9 @@ class StrictMock(object):
         self.__dict__["__caller"] = self._get_caller(1)
 
         caller_frame = inspect.currentframe().f_back
-        caller_frame_info = inspect.getframeinfo(caller_frame)
+        # loading the context ends up reading files from disk and that might block
+        # the event loop, so we don't do it.
+        caller_frame_info = inspect.getframeinfo(caller_frame, context=0)
         self.__dict__["_caller_frame_info"] = caller_frame_info
 
         self._setup_magic_methods()


### PR DESCRIPTION
We don't really need the context (surrounding lines of code), and that
blocks the async loop and slows down tests as it has to read the
contents of the file from disk.