### PR TITLE
[global] add isort and `make format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 TESTSLIDE_FORMAT?=documentation
 UNITTEST_VERBOSE?=1
 ifeq ($(UNITTEST_VERBOSE),0)
-UNITTEST_ARGS := 
+UNITTEST_ARGS :=
 else
 UNITTEST_ARGS := --verbose
 endif
@@ -26,7 +26,7 @@ V?=0
 ifeq ($(V),0)
 Q := @python util/run_silent_if_successful.py
 else
-Q := 
+Q :=
 endif
 
 ##
@@ -99,7 +99,22 @@ flake8:
 .PHONY: black
 black:
 	@printf "${TERM_BRIGHT}BLACK ${ALL_SRCS}\n${TERM_NONE}"
-	${Q} black --check $(ALL_SRCS)
+	${Q} black --check $(ALL_SRCS) || { echo "Formatting errors found, try running 'make format'."; exit 1; }
+
+.PHONY: isort
+isort:
+	@printf "${TERM_BRIGHT}ISORT ${ALL_SRCS}\n${TERM_NONE}"
+	${Q} isort --check-only --profile black $(ALL_SRCS) || { echo "Formatting errors found, try running 'make format'."; exit 1; }
+
+.PHONY: format_isort
+format_isort:
+	@printf "${TERM_BRIGHT}FORMAT PYFMT ${ALL_SRCS}\n${TERM_NONE}"
+	${Q} isort --profile black $(ALL_SRCS)
+
+.PHONY: format_black
+format_black:
+	@printf "${TERM_BRIGHT}FORMAT BLACK ${ALL_SRCS}\n${TERM_NONE}"
+	${Q} black $(ALL_SRCS)
 
 .PHONY: tests
 tests: \
@@ -107,7 +122,13 @@ tests: \
 	testslide_tests \
 	mypy \
 	flake8 \
+	isort \
 	black
+
+.PHONY: format
+format: \
+    format_isort \
+	format_black
 
 ##
 ## Coverage

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
             "coverage",
             "coveralls",
             "flake8",
+            "isort~=5.1",
             "mypy",
             "ipython",
             "sphinx",

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -7,11 +7,11 @@ import copy
 import os
 import os.path
 import pty
+import re
 import subprocess
 import sys
 import threading
 import unittest
-import re
 
 
 class TestCliBase(unittest.TestCase):
@@ -559,24 +559,25 @@ class TestCliDocumentFormatter(ExceptionCauseTest, TestCliBase):
         self.argv.append("--dsl-debug")
         self.run_testslide(
             expected_return_code=1,
-            expected_stdout_startswith=(
+            expected_regex_in_stdout=(
                 "top context\n"
-                "  example: passing_example @ tests/sample_tests.py:34\n"
+                "  example: passing_example @ tests/sample_tests.py:\d+\n"
                 "  passing example: PASS\n"
-                "  example: failing_example @ tests/sample_tests.py:38\n"
-                "  failing example: SimulatedFailure: test failure (extra)\n"
-                "  example: focused_example @ tests/sample_tests.py:43\n"
-                "  *focused example: PASS\n"
+                "  example: failing_example @ tests/sample_tests.py:\d+\n"
+                "  failing example: SimulatedFailure: test failure \(extra\)\n"
+                "  example: focused_example @ tests/sample_tests.py:\d+\n"
+                "  \*focused example: PASS\n"
                 "  skipped example: SKIP\n"
-                "  example: unittest_SkipTest @ tests/sample_tests.py:51\n"
+                "  example: unittest_SkipTest @ tests/sample_tests.py:\d+\n"
                 "  unittest SkipTest: SKIP\n"
                 "  nested context\n"
-                "    example: passing_nested_example @ tests/sample_tests.py:58\n"
+                "    example: passing_nested_example @ tests/sample_tests.py:\d+\n"
                 "    passing nested example: PASS\n"
                 "tests.sample_tests.SampleTestCase\n"
                 "  test_failing: AssertionError: Third\n"
                 "  test_passing: PASS\n"
                 "  test_skipped: SKIP\n"
+                ".*"
             ),
         )
 
@@ -616,18 +617,18 @@ class TestCliProgressFormatter(ExceptionCauseTest, TestCliBase):
         self.argv.append("--dsl-debug")
         self.run_testslide(
             expected_return_code=1,
-            expected_stdout_startswith=(
+            expected_regex_in_stdout=(
                 "\n"
-                "example: passing_example @ tests/sample_tests.py:34\n"
+                "example: passing_example @ tests/sample_tests.py:\d+\n"
                 ".\n"
-                "example: failing_example @ tests/sample_tests.py:38\n"
+                "example: failing_example @ tests/sample_tests.py:\d+\n"
                 "F\n"
-                "example: focused_example @ tests/sample_tests.py:43\n"
+                "example: focused_example @ tests/sample_tests.py:\d+\n"
                 ".\n"
                 "S\n"
-                "example: unittest_SkipTest @ tests/sample_tests.py:51\n"
+                "example: unittest_SkipTest @ tests/sample_tests.py:\d+\n"
                 "S\n"
-                "example: passing_nested_example @ tests/sample_tests.py:58\n"
+                "example: passing_nested_example @ tests/sample_tests.py:\d+\n"
                 ".\n"
                 "F\n"
                 ".\n"
@@ -748,23 +749,23 @@ class TestCliLongFormatter(ExceptionCauseTest, TestCliBase):
         self.argv.append("--dsl-debug")
         self.run_testslide(
             expected_return_code=1,
-            expected_stdout_startswith=(
+            expected_regex_in_stdout=(
                 "top context: \n"
-                "  example: passing_example @ tests/sample_tests.py:34\n"
+                "  example: passing_example @ tests/sample_tests.py:\d+\n"
                 "  passing example: PASS\n"
                 "top context: \n"
-                "  example: failing_example @ tests/sample_tests.py:38\n"
-                "  failing example: SimulatedFailure: test failure (extra)\n"
+                "  example: failing_example @ tests/sample_tests.py:\d+\n"
+                "  failing example: SimulatedFailure: test failure \(extra\)\n"
                 "top context: \n"
-                "  example: focused_example @ tests/sample_tests.py:43\n"
-                "  *focused example: PASS\n"
+                "  example: focused_example @ tests/sample_tests.py:\d+\n"
+                "  \*focused example: PASS\n"
                 "top context: \n"
                 "  skipped example: SKIP\n"
                 "top context: \n"
-                "  example: unittest_SkipTest @ tests/sample_tests.py:51\n"
+                "  example: unittest_SkipTest @ tests/sample_tests.py:\d+\n"
                 "  unittest SkipTest: SKIP\n"
                 "top context, nested context: \n"
-                "  example: passing_nested_example @ tests/sample_tests.py:58\n"
+                "  example: passing_nested_example @ tests/sample_tests.py:\d+\n"
                 "  passing nested example: PASS\n"
                 "tests.sample_tests.SampleTestCase: \n"
                 "  test_failing: AssertionError: Third\n"
@@ -772,5 +773,6 @@ class TestCliLongFormatter(ExceptionCauseTest, TestCliBase):
                 "  test_passing: PASS\n"
                 "tests.sample_tests.SampleTestCase: \n"
                 "  test_skipped: SKIP\n"
+                ".*"
             ),
         )

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -3,19 +3,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
 import asyncio
-import unittest
-import time
-
-from unittest.mock import Mock, call, patch
-
-from testslide import Context, AggregatedExceptions, SlowCallback, reset, _ExampleRunner
-from testslide.runner import QuietFormatter
-from testslide.dsl import context, xcontext, fcontext
 import os
 import subprocess
+import sys
+import time
+import unittest
 from typing import List
+from unittest.mock import Mock, call, patch
+
+from testslide import AggregatedExceptions, Context, SlowCallback, _ExampleRunner, reset
+from testslide.dsl import context, fcontext, xcontext
+from testslide.runner import QuietFormatter
 
 
 class SomeTestCase(unittest.TestCase):

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -4,13 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import inspect
-from typing import Type, TypeVar, Optional
-from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
-import testslide.lib
-from . import sample_module
-from testslide import StrictMock
 import unittest.mock
+from typing import Optional, Type, TypeVar
 
+import testslide.lib
+from testslide import StrictMock
+from testslide.dsl import Skip, context, fcontext, xcontext  # noqa: F401
+
+from . import sample_module
 
 T = TypeVar("T")
 

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import testslide
+
 from . import sample_module
 
 

--- a/tests/mock_async_callable_testslide.py
+++ b/tests/mock_async_callable_testslide.py
@@ -3,19 +3,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import testslide
-from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
+import contextlib
 
+import testslide
+from testslide.dsl import Skip, context, fcontext, xcontext  # noqa: F401
+from testslide.lib import TypeCheckError
 from testslide.mock_callable import (
-    mock_async_callable,
     NotACoroutine,
     UndefinedBehaviorForCall,
     UnexpectedCallArguments,
+    mock_async_callable,
 )
-import contextlib
 from testslide.strict_mock import StrictMock
+
 from . import sample_module
-from testslide.lib import TypeCheckError
 
 
 @context("mock_async_callable()")

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -3,20 +3,21 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import testslide
-from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
-
-from testslide.mock_callable import (
-    mock_callable,
-    UndefinedBehaviorForCall,
-    UnexpectedCallReceived,
-    UnexpectedCallArguments,
-)
 import contextlib
-from testslide.strict_mock import StrictMock
 import os
-from . import sample_module
+
+import testslide
+from testslide.dsl import Skip, context, fcontext, xcontext  # noqa: F401
 from testslide.lib import TypeCheckError
+from testslide.mock_callable import (
+    UndefinedBehaviorForCall,
+    UnexpectedCallArguments,
+    UnexpectedCallReceived,
+    mock_callable,
+)
+from testslide.strict_mock import StrictMock
+
+from . import sample_module
 
 
 @context("mock_callable()")

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -3,14 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
 import contextlib
+import sys
+from typing import Optional
 
-from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
+from testslide.dsl import Skip, context, fcontext, xcontext  # noqa: F401
+from testslide.lib import TypeCheckError
 from testslide.mock_callable import _MockCallableDSL
 from testslide.strict_mock import StrictMock
-from typing import Optional
-from testslide.lib import TypeCheckError
 
 
 class _PrivateClass(object):

--- a/tests/patch_attribute_testslide.py
+++ b/tests/patch_attribute_testslide.py
@@ -3,12 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
-from . import sample_module
 from testslide import StrictMock
+from testslide.dsl import Skip, context, fcontext, xcontext  # noqa: F401
+from testslide.patch_attribute import unpatch_all_mocked_attributes
 from testslide.strict_mock import UndefinedAttribute
 
-from testslide.patch_attribute import unpatch_all_mocked_attributes
+from . import sample_module
 
 
 @context("patch_attribute()")

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Dict, Union, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 attribute = "value"
 

--- a/tests/sample_tests.py
+++ b/tests/sample_tests.py
@@ -3,10 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from testslide.dsl import context
-import unittest
 import os
 import sys
+import unittest
+
+from testslide.dsl import context
 
 
 class SimulatedFailure(Exception):

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -3,6 +3,17 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
+import copy
+import functools
+import inspect
+import os
+import re
+import sys
+import unittest
+
+from testslide.dsl import Skip, context, fcontext, xcontext  # noqa: F401
+from testslide.lib import TypeCheckError
 from testslide.strict_mock import (
     NonAwaitableReturn,
     NonCallableValue,
@@ -10,18 +21,6 @@ from testslide.strict_mock import (
     StrictMock,
     UndefinedAttribute,
 )
-
-import contextlib
-import copy
-import functools
-import inspect
-import sys
-import re
-import unittest
-import os
-
-from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
-from testslide.lib import TypeCheckError
 
 
 def extra_arg_with_wraps(f):

--- a/tests/testcase_unittest.py
+++ b/tests/testcase_unittest.py
@@ -5,9 +5,10 @@
 
 import asyncio
 import csv
-import testslide
-import unittest
 import sys
+import unittest
+
+import testslide
 
 
 class SomeClass:

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -10,8 +10,6 @@ if "COVERAGE_PROCESS_START" in os.environ:
 
     coverage.process_startup()
 
-from contextlib import contextmanager
-
 import asyncio
 import asyncio.log
 import contextlib
@@ -21,13 +19,14 @@ import sys
 import types
 import unittest
 import warnings
+from contextlib import contextmanager
+from typing import List
 
+import testslide.matchers
 import testslide.mock_callable
 import testslide.mock_constructor
-import testslide.matchers
 import testslide.patch_attribute
 from testslide.strict_mock import StrictMock  # noqa
-from typing import List
 
 if sys.version_info < (3, 6):
     raise RuntimeError("Python >=3.6 required.")

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -6,15 +6,15 @@
 import argparse
 import os
 import re
-from time import time
 import sys
-
-from contextlib import contextmanager
-
-from . import _TestSlideTestResult, Context
-from .runner import Runner, ProgressFormatter, DocumentFormatter, LongFormatter
 import unittest
+from contextlib import contextmanager
+from time import time
+
 import testslide.dsl
+
+from . import Context, _TestSlideTestResult
+from .runner import DocumentFormatter, LongFormatter, ProgressFormatter, Runner
 from .strict_mock import StrictMock
 
 _unittest_testcase_loaded = False

--- a/testslide/dsl.py
+++ b/testslide/dsl.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import inspect
 import functools
+import inspect
 from re import sub as _sub
 
 from . import Context as _Context

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 import typeguard
 
-
 ##
 ## Type validation
 ##

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -4,14 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import asyncio
-import inspect
 import functools
-from typing import List, Callable, Tuple, Any, Dict
+import inspect
+from typing import Any, Callable, Dict, List, Tuple
+
 import testslide
+from testslide.lib import _validate_return_type, _wrap_signature_and_type_validation
 from testslide.strict_mock import StrictMock
-from testslide.lib import _wrap_signature_and_type_validation, _validate_return_type
-from .patch import _patch, _is_instance_method
+
 from .lib import _bail_if_private
+from .patch import _is_instance_method, _patch
 
 
 def mock_callable(target, method, allow_private=False, type_validation=True):

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -5,15 +5,16 @@
 
 import gc
 import inspect
+from typing import Any, Callable, Dict, List
 
 import testslide
-from testslide.mock_callable import _MockCallableDSL, _CallableMock
+from testslide.mock_callable import _CallableMock, _MockCallableDSL
+
 from .lib import (
     _bail_if_private,
     _validate_callable_arg_types,
     _validate_callable_signature,
 )
-from typing import List, Callable, Dict, Any
 
 _DO_NOT_COPY_CLASS_ATTRIBUTES = (
     "__dict__",

--- a/testslide/patch.py
+++ b/testslide/patch.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import inspect
-from typing import Callable, Any
+from typing import Any, Callable
 
 
 class _DescriptorProxy(object):

--- a/testslide/patch_attribute.py
+++ b/testslide/patch_attribute.py
@@ -3,11 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any, Callable, Dict, Tuple
+
 import testslide
-from .patch import _patch
-from .lib import _bail_if_private
 from testslide.strict_mock import UndefinedAttribute
-from typing import Callable, Any, Dict, Tuple
+
+from .lib import _bail_if_private
+from .patch import _patch
 
 _restore_values: Dict[Tuple[Any, str], Any] = {}
 _unpatchers: Dict[Tuple[Any, str], Callable] = {}

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -6,15 +6,15 @@
 import inspect
 import io
 import os
-import psutil
 import random
 import sys
 import time
 import traceback
+from contextlib import redirect_stderr, redirect_stdout
+
+import psutil
 
 from . import AggregatedExceptions, Skip, _ExampleRunner
-from contextlib import redirect_stdout, redirect_stderr
-
 
 ##
 ## Base

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -2,13 +2,13 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import dis
 import copy
+import dis
 import inspect
 import os.path
-import testslide.lib
-from typing import Optional, Any
+from typing import Any, Optional
 
+import testslide.lib
 import testslide.mock_callable
 
 

--- a/util/run_silent_if_successful.py
+++ b/util/run_silent_if_successful.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import threading
 
-
 master_pty_fd, slave_pty_fd = pty.openpty()
 read_data = []
 


### PR DESCRIPTION
**What:**

* Create a new command `make format` to apply all the formatters.
* Add isort formatter
* Actually apply all the formatters
* Also moved all the relative import to non-relative when possible (just
  standardizing on something).



**Why:**

My editor kept autoformatting the code every time I touched it, applying isort
also, this standardizes it and gives a helpful command to ease the formatting.

**How:**

Added isort test rule to the makefile, and a new `format` rule that runs both
black and isort to reformat the code.

**Risks:**

Little, maybe someone with local code might have some merge conflict.



<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->