### PR TITLE
Surface type errors

### DIFF
--- a/docs/patching/mock_callable/index.rst
+++ b/docs/patching/mock_callable/index.rst
@@ -407,7 +407,7 @@ This is particularly helpful when changes are introduced to the code: if a mocke
 Type Validation
 ---------------
 
-If typing annotation information is available, ``mock_callable()`` validates types of objects passing through the mock. If an invalid type is detected, it will raise ``TypeError``.
+If typing annotation information is available, ``mock_callable()`` validates types of objects passing through the mock. If an invalid type is detected, it will raise ``testslide.lib.TypeCheckError``.
 
 This feature is enabled by default. If you need to disable it (potentially due to a bug, please report!), you can do so by ``mock_callable(target, name, type_validation=False)``.
 
@@ -416,7 +416,7 @@ Call Argument Types
 
 .. code-block:: python
 
-  import testslide
+  import testslide, testslide.lib
   
   class SomeClass:
       def some_method(self, message: str):
@@ -429,8 +429,8 @@ Call Argument Types
               "mocked world"
           )
           self.assertEqual(some_class_instance.some_method("hello"), "mocked world")
-          with self.assertRaises(TypeError):
-              # TypeError: Call with incompatible argument types:
+          with self.assertRaises(testslide.lib.TypeCheckError):
+              # TypeCheckError: Call with incompatible argument types:
               # 'message': type of message must be str; got int instead
               some_class_instance.some_method(1)
 
@@ -439,7 +439,7 @@ Return Value Type
 
 .. code-block:: python
 
-  import testslide
+  import testslide, testslide.lib
   
   class SomeClass:
       def one(self) -> int:
@@ -451,8 +451,8 @@ Return Value Type
           self.mock_callable(some_class_instance, "one").to_return_value(
               "one"
           )
-          with self.assertRaises(TypeError):
-              # TypeError: type of return must be int; got str instead
+          with self.assertRaises(testslide.lib.TypeCheckError):
+              # TypeCheckError: type of return must be int; got str instead
               some_class_instance.one()
 
 Limitations

--- a/docs/patching/mock_constructor/index.rst
+++ b/docs/patching/mock_constructor/index.rst
@@ -64,7 +64,7 @@ Type Validation
 .. code-block:: python
 
   import sys
-  import testslide
+  import testslide, testslide.lib
   
   class Messenger:
       def __init__(self, message: str):
@@ -74,8 +74,8 @@ Type Validation
       def test_argument_type_validation(self):
           messenger_mock = testslide.StrictMock(template=Messenger)
           self.mock_constructor(sys.modules[__name__], "Messenger").to_return_value(messenger_mock)
-          with self.assertRaises(TypeError):
-              # TypeError: Call with incompatible argument types:
+          with self.assertRaises(testslide.lib.TypeCheckError):
+              # TypeCheckError: Call with incompatible argument types:
               # 'message': type of message must be str; got int instead
               Messenger(message=1)
 

--- a/docs/strict_mock/index.rst
+++ b/docs/strict_mock/index.rst
@@ -170,7 +170,7 @@ When type annotation is available for attributes, ``StrictMock`` won't allow set
 
   In [5]: mock.VERSION = 1.2
   (...)
-  TypeError: type of VERSION must be str; got float instead
+  TypeCheckError: type of VERSION must be str; got float instead
 
 Method Signature
 ================
@@ -192,7 +192,7 @@ Method signatures must match the signature of the equivalent method at the templ
 
   In [5]: mock.is_odd(2, 'invalid')
   (...)
-  TypeError: too many positional arguments
+  TypeCheckError: too many positional arguments
 
 Method Argument Type
 ====================
@@ -217,7 +217,7 @@ Methods with type annotation will have call arguments validated against it and i
 
   In [6]: mock.is_odd("1")
   (...)
-  TypeError: Call with incompatible argument types:
+  TypeCheckError: Call with incompatible argument types:
     'x': type of x must be int; got str instead
 
 Method Return Type
@@ -238,7 +238,7 @@ Methods with return type annotated will have its return value type validated as 
 
   In [4]: mock.is_odd = lambda x: 1
   (...)
-  TypeError: type of return must be bool; got int instead
+  TypeCheckError: type of return must be bool; got int instead
 
 Setting Methods With Callables
 ==============================

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -40,7 +40,7 @@ def _validate_callable_arg_types(context):
     @context.function
     def assert_fails(self, *args, **kwargs):
         with self.assertRaisesRegex(
-            testslide.lib.RuntimeTypeError,
+            testslide.lib.TypeCheckError,
             "Call to "
             + self.callable_template.__name__
             + " has incompatible argument types",
@@ -87,7 +87,7 @@ def _validate_callable_arg_types(context):
     @context.example
     def gives_correct_error_message_for_invalid_types(self):
         with self.assertRaises(
-            testslide.lib.RuntimeTypeError,
+            testslide.lib.TypeCheckError,
             msg=(
                 "Call to test_function has incompatible argument types:\n"
                 "  'arg1': type of arg1 must be str; got int instead\n"
@@ -298,7 +298,7 @@ def _validate_return_type(context):
         assert_regex = (
             r"(?s)type of return must be .+; got .+ instead: .+Defined at .+:\d+"
         )
-        with self.assertRaisesRegex(testslide.lib.RuntimeTypeError, assert_regex):
+        with self.assertRaisesRegex(testslide.lib.TypeCheckError, assert_regex):
             testslide.lib._validate_return_type(
                 self.callable_template, value, self.caller_frame_info
             )
@@ -350,7 +350,7 @@ def _validate_return_type(context):
     @context.example
     def fails_for_valid_forward_reference_but_bad_type_passed(self):
         with self.assertRaisesRegex(
-            testslide.lib.RuntimeTypeError,
+            testslide.lib.TypeCheckError,
             "type of return must be one of .*; got int instead:",
         ):
             testslide.lib._validate_return_type(

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -40,7 +40,7 @@ def _validate_callable_arg_types(context):
     @context.function
     def assert_fails(self, *args, **kwargs):
         with self.assertRaisesRegex(
-            TypeError,
+            testslide.lib.RuntimeTypeError,
             "Call to "
             + self.callable_template.__name__
             + " has incompatible argument types",
@@ -87,7 +87,7 @@ def _validate_callable_arg_types(context):
     @context.example
     def gives_correct_error_message_for_invalid_types(self):
         with self.assertRaises(
-            TypeError,
+            testslide.lib.RuntimeTypeError,
             msg=(
                 "Call to test_function has incompatible argument types:\n"
                 "  'arg1': type of arg1 must be str; got int instead\n"
@@ -298,7 +298,7 @@ def _validate_return_type(context):
         assert_regex = (
             r"(?s)type of return must be .+; got .+ instead: .+Defined at .+:\d+"
         )
-        with self.assertRaisesRegex(TypeError, assert_regex):
+        with self.assertRaisesRegex(testslide.lib.RuntimeTypeError, assert_regex):
             testslide.lib._validate_return_type(
                 self.callable_template, value, self.caller_frame_info
             )
@@ -350,7 +350,8 @@ def _validate_return_type(context):
     @context.example
     def fails_for_valid_forward_reference_but_bad_type_passed(self):
         with self.assertRaisesRegex(
-            TypeError, "type of return must be one of .*; got int instead:"
+            testslide.lib.RuntimeTypeError,
+            "type of return must be one of .*; got int instead:",
         ):
             testslide.lib._validate_return_type(
                 Foo.get_maybe_foo, 33, self.caller_frame_info

--- a/tests/mock_async_callable_testslide.py
+++ b/tests/mock_async_callable_testslide.py
@@ -15,6 +15,7 @@ from testslide.mock_callable import (
 import contextlib
 from testslide.strict_mock import StrictMock
 from . import sample_module
+from testslide.lib import RuntimeTypeError
 
 
 @context("mock_async_callable()")
@@ -122,8 +123,8 @@ def mock_async_callable_tests(context):
                         return 1
 
                     @context.example
-                    async def raises_TypeError(self):
-                        with self.assertRaises(TypeError):
+                    async def raises_RuntimeTypeError(self):
+                        with self.assertRaises(RuntimeTypeError):
                             await self.callable_target(
                                 *self.call_args, **self.call_kwargs
                             )

--- a/tests/mock_async_callable_testslide.py
+++ b/tests/mock_async_callable_testslide.py
@@ -15,7 +15,7 @@ from testslide.mock_callable import (
 import contextlib
 from testslide.strict_mock import StrictMock
 from . import sample_module
-from testslide.lib import RuntimeTypeError
+from testslide.lib import TypeCheckError
 
 
 @context("mock_async_callable()")
@@ -123,8 +123,8 @@ def mock_async_callable_tests(context):
                         return 1
 
                     @context.example
-                    async def raises_RuntimeTypeError(self):
-                        with self.assertRaises(RuntimeTypeError):
+                    async def raises_TypeCheckError(self):
+                        with self.assertRaises(TypeCheckError):
                             await self.callable_target(
                                 *self.call_args, **self.call_kwargs
                             )

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -16,6 +16,7 @@ import contextlib
 from testslide.strict_mock import StrictMock
 import os
 from . import sample_module
+from testslide.lib import RuntimeTypeError
 
 
 @context("mock_callable()")
@@ -156,12 +157,12 @@ def mock_callable_tests(context):
                         @context.sub_context
                         def arguments(context):
                             @context.example
-                            def raises_TypeError_for_invalid_types(self):
+                            def raises_RuntimeTypeError_for_invalid_types(self):
                                 bad_signature_args = (1234 for arg in self.call_args)
                                 bad_signature_kargs = {
                                     k: 1234 for k, v in self.call_kwargs.items()
                                 }
-                                with self.assertRaises(TypeError):
+                                with self.assertRaises(RuntimeTypeError):
                                     self.callable_target(
                                         *bad_signature_args, **bad_signature_kargs
                                     )
@@ -193,8 +194,8 @@ def mock_callable_tests(context):
                                     context.memoize("value", lambda self: 1)
 
                                     @context.example
-                                    def raises_TypeError(self):
-                                        with self.assertRaises(TypeError):
+                                    def raises_RuntimeTypeError(self):
+                                        with self.assertRaises(RuntimeTypeError):
                                             self.callable_target(
                                                 *self.call_args, **self.call_kwargs
                                             )

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -16,7 +16,7 @@ import contextlib
 from testslide.strict_mock import StrictMock
 import os
 from . import sample_module
-from testslide.lib import RuntimeTypeError
+from testslide.lib import TypeCheckError
 
 
 @context("mock_callable()")
@@ -157,12 +157,12 @@ def mock_callable_tests(context):
                         @context.sub_context
                         def arguments(context):
                             @context.example
-                            def raises_RuntimeTypeError_for_invalid_types(self):
+                            def raises_TypeCheckError_for_invalid_types(self):
                                 bad_signature_args = (1234 for arg in self.call_args)
                                 bad_signature_kargs = {
                                     k: 1234 for k, v in self.call_kwargs.items()
                                 }
-                                with self.assertRaises(RuntimeTypeError):
+                                with self.assertRaises(TypeCheckError):
                                     self.callable_target(
                                         *bad_signature_args, **bad_signature_kargs
                                     )
@@ -194,8 +194,8 @@ def mock_callable_tests(context):
                                     context.memoize("value", lambda self: 1)
 
                                     @context.example
-                                    def raises_RuntimeTypeError(self):
-                                        with self.assertRaises(RuntimeTypeError):
+                                    def raises_TypeCheckError(self):
+                                        with self.assertRaises(TypeCheckError):
                                             self.callable_target(
                                                 *self.call_args, **self.call_kwargs
                                             )

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -10,6 +10,7 @@ from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 from testslide.mock_callable import _MockCallableDSL
 from testslide.strict_mock import StrictMock
 from typing import Optional
+from testslide.lib import RuntimeTypeError
 
 
 class _PrivateClass(object):
@@ -520,7 +521,7 @@ def mock_constructor(context):
 
         @context.example
         def it_fails_with_invalid_types(self):
-            with self.assertRaises(TypeError):
+            with self.assertRaises(RuntimeTypeError):
                 self.target(message=1234)
 
         @context.sub_context("with type_validation=False")

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -10,7 +10,7 @@ from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
 from testslide.mock_callable import _MockCallableDSL
 from testslide.strict_mock import StrictMock
 from typing import Optional
-from testslide.lib import RuntimeTypeError
+from testslide.lib import TypeCheckError
 
 
 class _PrivateClass(object):
@@ -521,7 +521,7 @@ def mock_constructor(context):
 
         @context.example
         def it_fails_with_invalid_types(self):
-            with self.assertRaises(RuntimeTypeError):
+            with self.assertRaises(TypeCheckError):
                 self.target(message=1234)
 
         @context.sub_context("with type_validation=False")

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -21,7 +21,7 @@ import unittest
 import os
 
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
-from testslide.lib import RuntimeTypeError
+from testslide.lib import TypeCheckError
 
 
 def extra_arg_with_wraps(f):
@@ -442,19 +442,19 @@ def strict_mock(context):
                             self.strict_mock.non_callable = StrictMock()
 
                         @context.example
-                        def raises_RuntimeTypeError_when_setting_invalid_type(self):
-                            with self.assertRaises(RuntimeTypeError):
+                        def raises_TypeCheckError_when_setting_invalid_type(self):
+                            with self.assertRaises(TypeCheckError):
                                 self.strict_mock.non_callable = 1
 
                         @context.example
-                        def raises_RuntimeTypeError_when_setting_with_mock_with_invalid_type_template(
+                        def raises_TypeCheckError_when_setting_with_mock_with_invalid_type_template(
                             self,
                         ):
-                            with self.assertRaises(RuntimeTypeError):
+                            with self.assertRaises(TypeCheckError):
                                 self.strict_mock.non_callable = unittest.mock.Mock(
                                     spec=int
                                 )
-                            with self.assertRaises(RuntimeTypeError):
+                            with self.assertRaises(TypeCheckError):
                                 self.strict_mock.non_callable = StrictMock(template=int)
 
                         @context.sub_context("with type_validation=False")
@@ -565,7 +565,7 @@ def strict_mock(context):
                                                 self.test_method_name,
                                                 lambda message: None,
                                             )
-                                            with self.assertRaises(RuntimeTypeError):
+                                            with self.assertRaises(TypeCheckError):
                                                 getattr(
                                                     self.strict_mock,
                                                     self.test_method_name,
@@ -578,7 +578,7 @@ def strict_mock(context):
                                                 self.test_method_name,
                                                 lambda message: 1234,
                                             )
-                                            with self.assertRaises(RuntimeTypeError):
+                                            with self.assertRaises(TypeCheckError):
                                                 getattr(
                                                     self.strict_mock,
                                                     self.test_method_name,
@@ -973,7 +973,7 @@ def strict_mock(context):
                                         return "mock "
 
                                     setattr(self.strict_mock, self.method_name, mock)
-                                    with self.assertRaises(RuntimeTypeError):
+                                    with self.assertRaises(TypeCheckError):
                                         await getattr(
                                             self.strict_mock, self.method_name
                                         )(1)
@@ -986,7 +986,7 @@ def strict_mock(context):
                                     setattr(
                                         self.strict_mock, self.method_name, mock,
                                     )
-                                    with self.assertRaises(RuntimeTypeError):
+                                    with self.assertRaises(TypeCheckError):
                                         await getattr(
                                             self.strict_mock, self.method_name,
                                         )("message")

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -21,6 +21,7 @@ import unittest
 import os
 
 from testslide.dsl import context, xcontext, fcontext, Skip  # noqa: F401
+from testslide.lib import RuntimeTypeError
 
 
 def extra_arg_with_wraps(f):
@@ -441,19 +442,19 @@ def strict_mock(context):
                             self.strict_mock.non_callable = StrictMock()
 
                         @context.example
-                        def raises_TypeError_when_setting_invalid_type(self):
-                            with self.assertRaises(TypeError):
+                        def raises_RuntimeTypeError_when_setting_invalid_type(self):
+                            with self.assertRaises(RuntimeTypeError):
                                 self.strict_mock.non_callable = 1
 
                         @context.example
-                        def raises_TypeError_when_setting_with_mock_with_invalid_type_template(
+                        def raises_RuntimeTypeError_when_setting_with_mock_with_invalid_type_template(
                             self,
                         ):
-                            with self.assertRaises(TypeError):
+                            with self.assertRaises(RuntimeTypeError):
                                 self.strict_mock.non_callable = unittest.mock.Mock(
                                     spec=int
                                 )
-                            with self.assertRaises(TypeError):
+                            with self.assertRaises(RuntimeTypeError):
                                 self.strict_mock.non_callable = StrictMock(template=int)
 
                         @context.sub_context("with type_validation=False")
@@ -564,7 +565,7 @@ def strict_mock(context):
                                                 self.test_method_name,
                                                 lambda message: None,
                                             )
-                                            with self.assertRaises(TypeError):
+                                            with self.assertRaises(RuntimeTypeError):
                                                 getattr(
                                                     self.strict_mock,
                                                     self.test_method_name,
@@ -577,7 +578,7 @@ def strict_mock(context):
                                                 self.test_method_name,
                                                 lambda message: 1234,
                                             )
-                                            with self.assertRaises(TypeError):
+                                            with self.assertRaises(RuntimeTypeError):
                                                 getattr(
                                                     self.strict_mock,
                                                     self.test_method_name,
@@ -972,7 +973,7 @@ def strict_mock(context):
                                         return "mock "
 
                                     setattr(self.strict_mock, self.method_name, mock)
-                                    with self.assertRaises(TypeError):
+                                    with self.assertRaises(RuntimeTypeError):
                                         await getattr(
                                             self.strict_mock, self.method_name
                                         )(1)
@@ -985,7 +986,7 @@ def strict_mock(context):
                                     setattr(
                                         self.strict_mock, self.method_name, mock,
                                     )
-                                    with self.assertRaises(TypeError):
+                                    with self.assertRaises(RuntimeTypeError):
                                         await getattr(
                                             self.strict_mock, self.method_name,
                                         )("message")

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -24,6 +24,7 @@ class RuntimeTypeError(BaseException):
     BaseException to prevent the exception being caught and hidden by the code
     being tested, letting it surface to the test runner.
     """
+
     pass
 
 
@@ -98,7 +99,7 @@ def _validate_callable_signature(
     try:
         signature.bind(*args, **kwargs)
     except TypeError as e:
-        raise RuntimeTypeError("{}, {}: {}".format(repr(template), repr(attr_name), str(e)))
+        raise TypeError("{}, {}: {}".format(repr(template), repr(attr_name), str(e)))
     return True
 
 
@@ -187,7 +188,7 @@ def _validate_callable_arg_types(
                     continue
 
                 _validate_argument_type(expected_type, argname, args[idx])
-            except TypeError as type_error:
+            except RuntimeTypeError as type_error:
                 type_errors.append(f"{repr(argname)}: {type_error}")
 
     for argname, value in kwargs.items():
@@ -197,7 +198,7 @@ def _validate_callable_arg_types(
                 continue
 
             _validate_argument_type(expected_type, argname, value)
-        except TypeError as type_error:
+        except RuntimeTypeError as type_error:
             type_errors.append(f"{repr(argname)}: {type_error}")
 
     if type_errors:
@@ -269,9 +270,9 @@ def _validate_return_type(template, value, caller_frame_info):
     if expected_type:
         try:
             _validate_argument_type(expected_type, "return", value)
-        except TypeError as type_error:
+        except RuntimeTypeError as runtime_type_error:
             raise RuntimeTypeError(
-                f"{str(type_error)}: {repr(value)}\n"
+                f"{str(runtime_type_error)}: {repr(value)}\n"
                 f"Defined at {caller_frame_info.filename}:"
                 f"{caller_frame_info.lineno}"
             )

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -18,7 +18,7 @@ import typeguard
 ##
 
 
-class RuntimeTypeError(BaseException):
+class TypeCheckError(BaseException):
     """
     Raised when bad typing is detected during runtime. It inherits from
     BaseException to prevent the exception being caught and hidden by the code
@@ -163,7 +163,7 @@ def _validate_argument_type(expected_type, name: str, value) -> None:
         try:
             typeguard.check_type(name, value, expected_type)
         except TypeError as type_error:
-            raise RuntimeTypeError(str(type_error))
+            raise TypeCheckError(str(type_error))
 
 
 def _validate_callable_arg_types(
@@ -188,7 +188,7 @@ def _validate_callable_arg_types(
                     continue
 
                 _validate_argument_type(expected_type, argname, args[idx])
-            except RuntimeTypeError as type_error:
+            except TypeCheckError as type_error:
                 type_errors.append(f"{repr(argname)}: {type_error}")
 
     for argname, value in kwargs.items():
@@ -198,11 +198,11 @@ def _validate_callable_arg_types(
                 continue
 
             _validate_argument_type(expected_type, argname, value)
-        except RuntimeTypeError as type_error:
+        except TypeCheckError as type_error:
             type_errors.append(f"{repr(argname)}: {type_error}")
 
     if type_errors:
-        raise RuntimeTypeError(
+        raise TypeCheckError(
             "Call to "
             + callable_template.__name__
             + " has incompatible argument types:\n  "
@@ -270,8 +270,8 @@ def _validate_return_type(template, value, caller_frame_info):
     if expected_type:
         try:
             _validate_argument_type(expected_type, "return", value)
-        except RuntimeTypeError as runtime_type_error:
-            raise RuntimeTypeError(
+        except TypeCheckError as runtime_type_error:
+            raise TypeCheckError(
                 f"{str(runtime_type_error)}: {repr(value)}\n"
                 f"Defined at {caller_frame_info.filename}:"
                 f"{caller_frame_info.lineno}"


### PR DESCRIPTION
When runtime typing errors are detected raise `RuntimeTypeError(BaseException)` instead of plain `TypeError` to prevent code being tested to catch the exception, letting it surface to the test runner.

Closes #212 .