### PR TITLE
Add exception cause

### DIFF
--- a/tests/sample_tests.py
+++ b/tests/sample_tests.py
@@ -66,7 +66,13 @@ class SampleTestCase(unittest.TestCase):
 
     def test_failing(self):
         _cond_print("test_fail")
-        assert False
+        try:
+            try:
+                raise AssertionError("First")
+            except AssertionError as cause:
+                raise AssertionError("Second") from cause
+        except AssertionError as cause:
+            raise AssertionError("Third") from cause
 
     @unittest.skip("skip")
     def test_skipped(self):

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -180,15 +180,15 @@ class ColorFormatterMixin(BaseFormatter):
 
 
 class FailurePrinterMixin(ColorFormatterMixin):
-    def _print_stack_trace(self, exception: BaseException, cause: int) -> None:
-        indent = "  " * cause
-        if cause:
+    def _print_stack_trace(self, exception: BaseException, cause_depth: int) -> None:
+        indent = "  " * cause_depth
+        if cause_depth:
             self.print_red(f"\n    {indent}Caused by ", end="")
 
         self.print_red(
             "{exception_class}: {message}".format(
                 exception_class=exception.__class__.__name__,
-                message="\n    ".join(str(exception).split("\n")),
+                message=f"\n{indent}    ".join(str(exception).split("\n")),
             )
         )
         for path, line, function_name, text in traceback.extract_tb(
@@ -214,7 +214,7 @@ class FailurePrinterMixin(ColorFormatterMixin):
             )
 
         if exception.__cause__:
-            self._print_stack_trace(exception.__cause__, cause=cause + 1)
+            self._print_stack_trace(exception.__cause__, cause_depth=cause_depth + 1)
 
     def print_failed_example(self, number, example, exception):
         self.print_white(
@@ -230,7 +230,7 @@ class FailurePrinterMixin(ColorFormatterMixin):
             self.print_red(
                 "    {number}) ".format(number=number + 1,), end="",
             )
-            self._print_stack_trace(exception, cause=0)
+            self._print_stack_trace(exception, cause_depth=0)
 
 
 class SlowImportWarningMixin(ColorFormatterMixin):

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -180,6 +180,42 @@ class ColorFormatterMixin(BaseFormatter):
 
 
 class FailurePrinterMixin(ColorFormatterMixin):
+    def _print_stack_trace(self, exception: BaseException, cause: int) -> None:
+        indent = "  " * cause
+        if cause:
+            self.print_red(f"\n    {indent}Caused by ", end="")
+
+        self.print_red(
+            "{exception_class}: {message}".format(
+                exception_class=exception.__class__.__name__,
+                message="\n    ".join(str(exception).split("\n")),
+            )
+        )
+        for path, line, function_name, text in traceback.extract_tb(
+            exception.__traceback__
+        ):
+            if not self.show_testslide_stack_trace and path.startswith(
+                os.path.dirname(__file__)
+            ):
+                continue
+            if self.trim_path_prefix:
+                split = path.split(self.trim_path_prefix)
+                if len(split) == 2 and not split[0]:
+                    path = split[1]
+            self.print_cyan(
+                '{indent}      File "{path}", line {line}, in {function_name}\n'
+                "{indent}        {text}".format(
+                    indent=indent,
+                    path=path,
+                    line=line,
+                    function_name=function_name,
+                    text=text,
+                )
+            )
+
+        if exception.__cause__:
+            self._print_stack_trace(exception.__cause__, cause=cause + 1)
+
     def print_failed_example(self, number, example, exception):
         self.print_white(
             "  {number}) {context}: {example}".format(
@@ -192,27 +228,9 @@ class FailurePrinterMixin(ColorFormatterMixin):
             exception_list = [exception]
         for number, exception in enumerate(exception_list):
             self.print_red(
-                "    {number}) {exception_class}: {message}".format(
-                    number=number + 1,
-                    exception_class=exception.__class__.__name__,
-                    message="\n    ".join(str(exception).split("\n")),
-                )
+                "    {number}) ".format(number=number + 1,), end="",
             )
-            for path, line, function_name, text in traceback.extract_tb(
-                exception.__traceback__
-            ):
-                if not self.show_testslide_stack_trace and path.startswith(
-                    os.path.dirname(__file__)
-                ):
-                    continue
-                if self.trim_path_prefix:
-                    split = path.split(self.trim_path_prefix)
-                    if len(split) == 2 and not split[0]:
-                        path = split[1]
-                self.print_cyan(
-                    '      File "{}", line {}, in {}\n'
-                    "        {}".format(path, line, function_name, text)
-                )
+            self._print_stack_trace(exception, cause=0)
 
 
 class SlowImportWarningMixin(ColorFormatterMixin):
@@ -410,7 +428,7 @@ class DocumentFormatter(DSLDebugMixin, SlowImportWarningMixin, FailurePrinterMix
             self.print_cyan("  Not executed: ", len(not_executed_examples))
 
 
-class LongFormatter(DSLDebugMixin, SlowImportWarningMixin, ColorFormatterMixin):
+class LongFormatter(DSLDebugMixin, SlowImportWarningMixin, FailurePrinterMixin):
     def get_dsl_debug_indent(self, example):
         return "  "
 
@@ -472,40 +490,6 @@ class LongFormatter(DSLDebugMixin, SlowImportWarningMixin, ColorFormatterMixin):
                 skip_text="" if self._color_output() else ": SKIP",
             )
         )
-
-    def print_failed_example(self, number, example, exception):
-        self.print_white(
-            "  {number}) {context}: {example}".format(
-                number=number, context=example.context.full_name, example=example
-            )
-        )
-        if type(exception) is AggregatedExceptions:
-            exception_list = exception.exceptions
-        else:
-            exception_list = [exception]
-        for number, exception in enumerate(exception_list):
-            self.print_red(
-                "    {number}) {exception_class}: {message}".format(
-                    number=number + 1,
-                    exception_class=exception.__class__.__name__,
-                    message="\n    ".join(str(exception).split("\n")),
-                )
-            )
-            for path, line, function_name, text in traceback.extract_tb(
-                exception.__traceback__
-            ):
-                if not self.show_testslide_stack_trace and path.startswith(
-                    os.path.dirname(__file__)
-                ):
-                    continue
-                if self.trim_path_prefix:
-                    split = path.split(self.trim_path_prefix)
-                    if len(split) == 2 and not split[0]:
-                        path = split[1]
-                self.print_cyan(
-                    '      File "{}", line {}, in {}\n'
-                    "        {}".format(path, line, function_name, text)
-                )
 
     def finish(self, not_executed_examples):
         super().finish(not_executed_examples)


### PR DESCRIPTION
Given:

```python
# repro.py
import testslide


class Cause(testslide.TestCase):
  def test_smoke(self):
    try:
      try:
        raise RuntimeError("First")
      except RuntimeError as cause:
        raise RuntimeError("Second") from cause
    except RuntimeError as cause:
      raise RuntimeError("Third") from cause
```

For reference, unittest reports it as:

```
$ python -m unittest repro
E
======================================================================
ERROR: test_smoke (repro.Cause)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/fornellas/src/TestSlide/repro.py", line 8, in test_smoke
    raise RuntimeError("First")
RuntimeError: First

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/fornellas/src/TestSlide/repro.py", line 10, in test_smoke
    raise RuntimeError("Second") from cause
RuntimeError: Second

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/fornellas/src/TestSlide/repro.py", line 12, in test_smoke
    raise RuntimeError("Third") from cause
RuntimeError: Third

----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
```

Here's how TestSlide was reporting:

```
$ python -m testslide.cli repro.py 
repro.Cause
  test_smoke: RuntimeError: Third

Failures:

  1) repro.Cause: test_smoke
    1) RuntimeError: Third
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/contextlib.py", line 120, in __exit__
        next(self.gen)
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
        yield
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/unittest/case.py", line 676, in run
        self._callTestMethod(testMethod)
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
        method()
      File "repro.py", line 12, in test_smoke
        raise RuntimeError("Third") from cause

Finished 1 example(s) in 0.6s 
  Failed: 1
```

Here's how things are with this PR:

```
$ python -m testslide.cli repro.py 
repro.Cause
  test_smoke: RuntimeError: Third

Failures:

  1) repro.Cause: test_smoke
    1) RuntimeError: Third
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/contextlib.py", line 120, in __exit__
        next(self.gen)
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
        yield
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/unittest/case.py", line 676, in run
        self._callTestMethod(testMethod)
      File "/home/fornellas/.pyenv/versions/3.8.4/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
        method()
      File "repro.py", line 12, in test_smoke
        raise RuntimeError("Third") from cause

      Caused by RuntimeError: Second
        File "repro.py", line 10, in test_smoke
          raise RuntimeError("Second") from cause

        Caused by RuntimeError: First
          File "repro.py", line 8, in test_smoke
            raise RuntimeError("First")

Finished 1 example(s) in 0.6s 
  Failed: 1
```

Closes #209.