### PR TITLE
Update docs theme and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# TestSlide: Fluent Python Testing
-
 ![TestSlide](./docs/testslide_logo.png)
 
 [![Build Status](https://travis-ci.com/facebookincubator/TestSlide.svg?branch=master)](https://travis-ci.com/facebookincubator/TestSlide)
@@ -9,9 +7,7 @@
 [![PyPI version](https://badge.fury.io/py/TestSlide.svg)](https://badge.fury.io/py/TestSlide)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-TestSlide makes writing tests fluid and easy. Whether you prefer classic [unit testing](https://docs.python.org/3/library/unittest.html), [TDD](https://en.wikipedia.org/wiki/Test-driven_development) or [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development), it helps you be productive, with its easy to use well behaved mocks and its awesome test runner.
-
-It is designed to work well with other test frameworks, so you can use it on top of existing `unittest.TestCase` without rewriting everything.
+A test framework for Python that enable [unit testing](https://docs.python.org/3/library/unittest.html) / [TDD](https://en.wikipedia.org/wiki/Test-driven_development) / [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development) to be productive and enjoyable. Its well behaved mocks with thorough API validations catches bugs both when code is first written or long in the future when it is changed. The flexibility of using them with existing `unittest.TestCase` or TestSlide's own test runner let users get its benefits without requiring refactoring existing code.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 [![PyPI version](https://badge.fury.io/py/TestSlide.svg)](https://badge.fury.io/py/TestSlide)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-A test framework for Python that enable [unit testing](https://docs.python.org/3/library/unittest.html) / [TDD](https://en.wikipedia.org/wiki/Test-driven_development) / [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development) to be productive and enjoyable. Its well behaved mocks with thorough API validations catches bugs both when code is first written or long in the future when it is changed. The flexibility of using them with existing `unittest.TestCase` or TestSlide's own test runner let users get its benefits without requiring refactoring existing code.
+A test framework for Python that enable [unit testing](https://docs.python.org/3/library/unittest.html) / [TDD](https://en.wikipedia.org/wiki/Test-driven_development) / [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development) to be productive and enjoyable.
+
+Its well behaved mocks with thorough API validations catches bugs both when code is first written or long in the future when it is changed.
+
+The flexibility of using them with existing `unittest.TestCase` or TestSlide's own test runner let users get its benefits without requiring refactoring existing code.
 
 ## Quickstart
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,11 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+import sphinx_kr_theme
+
+html_theme = "kr"  # or 'kr_basic'
+
+html_theme_path = [sphinx_kr_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -101,8 +105,14 @@ html_static_path = ["_static"]
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-# html_sidebars = {}
+html_sidebars = {
+    "**": [
+        "globaltoc.html",  # a coarse-grained table of contents for the whole documentation set, collapsed
+        "searchbox.html",  # the “quick search” box
+    ],
+}
 
+html_logo = "testslide_logo.png"
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,11 @@
 TestSlide
 =========
 
-A test framework for Python that enable `unit testing <https://docs.python.org/3/library/unittest.html>`_ / `TDD <https://en.wikipedia.org/wiki/Test-driven_development>`_/ `BDD <https://en.wikipedia.org/wiki/Behavior-driven_development>`_ to be productive and enjoyable. Its well behaved mocks with thorough API validations catches bugs both when code is first written or long in the future when it is changed. The flexibility of using them with existing ``unittest.TestCase`` or TestSlide's own test runner let users get its benefits without requiring refactoring existing code.
+A test framework for Python that enable `unit testing <https://docs.python.org/3/library/unittest.html>`_ / `TDD <https://en.wikipedia.org/wiki/Test-driven_development>`_/ `BDD <https://en.wikipedia.org/wiki/Behavior-driven_development>`_ to be productive and enjoyable.
+
+Its well behaved mocks with thorough API validations catches bugs both when code is first written or long in the future when it is changed.
+
+The flexibility of using them with existing ``unittest.TestCase`` or TestSlide's own test runner let users get its benefits without requiring refactoring existing code.
 
 Quickstart
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,7 @@
-TestSlide: Fluent Python Testing
-================================
+TestSlide
+=========
 
-.. image:: testslide_logo.png
-   :alt: TestSlide
-   :align: center
-
-TestSlide makes writing tests fluid and easy. Whether you prefer classic `unit testing <https://docs.python.org/3/library/unittest.html>`_, `TDD <https://en.wikipedia.org/wiki/Test-driven_development>`_ or `BDD <https://en.wikipedia.org/wiki/Behavior-driven_development>`_, it helps you be productive, with its easy to use well behaved mocks and its awesome test runner.
-
-It is designed to work well with other test frameworks, so you can use it on top of existing ``unittest.TestCase`` without rewriting everything.
+A test framework for Python that enable `unit testing <https://docs.python.org/3/library/unittest.html>`_ / `TDD <https://en.wikipedia.org/wiki/Test-driven_development>`_/ `BDD <https://en.wikipedia.org/wiki/Behavior-driven_development>`_ to be productive and enjoyable. Its well behaved mocks with thorough API validations catches bugs both when code is first written or long in the future when it is changed. The flexibility of using them with existing ``unittest.TestCase`` or TestSlide's own test runner let users get its benefits without requiring refactoring existing code.
 
 Quickstart
 ----------

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
             "ipython",
             "sphinx",
             "sphinx-autobuild",
-            "sphinx_rtd_theme",
+            "sphinx-kr-theme",
             "twine",
         ]
     },


### PR DESCRIPTION
- Changes to a leaner theme, with less color crash with the logo.
- Put the logo at **all** pages, not just at the first one.
- Update the first description at README & docs.

![image](https://user-images.githubusercontent.com/1386232/89100833-5d5ace80-d3f2-11ea-8561-bea47b21a705.png)
