### PR TITLE
fail when submitting coroutines to mock_callable

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -24,9 +24,6 @@ async def coro_fun(*args):
     return 1
 
 
-coro_fun()
-
-
 @context("mock_callable()")
 def mock_callable_tests(context):
 
@@ -107,28 +104,6 @@ def mock_callable_tests(context):
             "This fun is private"
         ).and_assert_called_once()
         t._privatefun()
-
-    @context.example
-    def return_value_raises_with_coroutine(self):
-        with self.assertRaises(ValueError):
-            self.mock_callable(
-                sample_module, "test_function", type_validation=False
-            ).to_return_value(coro_fun())
-
-    @context.example
-    def return_values_raises_with_coroutine(self):
-        with self.assertRaises(ValueError):
-            self.mock_callable(
-                sample_module, "test_function", type_validation=False
-            ).to_return_values([1, 2, coro_fun()])
-
-    @context.example
-    def with_implementation_raises_with_coroutine(self):
-        with self.assertRaises(ValueError):
-            self.mock_callable(
-                sample_module, "test_function", type_validation=False
-            ).with_implementation(coro_fun)
-            sample_module.test_function("a", "b")
 
     ##
     ## Shared Contexts
@@ -525,6 +500,13 @@ def mock_callable_tests(context):
                     self.callable_target(*other_args, **other_kwargs), self.value
                 )
 
+            @context.example
+            def return_value_raises_with_coroutine(self):
+                with self.assertRaises(ValueError):
+                    self.mock_callable(
+                        sample_module, "test_function", type_validation=False
+                    ).to_return_value(coro_fun())
+
         @context.sub_context(".to_return_values(values_list)")
         def to_return_values_values_list(context):
             context.memoize("value", lambda self: "first")
@@ -545,6 +527,13 @@ def mock_callable_tests(context):
                     self.assertEqual(
                         self.callable_target(*self.call_args, **self.call_kwargs), value
                     )
+
+            @context.example
+            def return_values_raises_with_coroutine(self):
+                with self.assertRaises(ValueError):
+                    self.mock_callable(
+                        sample_module, "test_function", type_validation=False
+                    ).to_return_values([1, 2, coro_fun()])
 
             @context.sub_context
             def when_list_is_exhausted(context):
@@ -685,6 +674,14 @@ def mock_callable_tests(context):
                     self.callable_target(*self.call_args, **self.call_kwargs),
                     self.func_return,
                 )
+
+            @context.example
+            def with_implementation_raises_with_coroutine(self):
+                with self.assertRaises(ValueError):
+                    self.mock_callable(
+                        sample_module, "test_function", type_validation=False
+                    ).with_implementation(coro_fun)
+                    sample_module.test_function("a", "b")
 
         @context.sub_context(".with_wrapper(wrapper_func)")
         def with_wrapper_wrappr_func(context):

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -20,6 +20,13 @@ from testslide.strict_mock import StrictMock
 from . import sample_module
 
 
+async def coro_fun(*args):
+    return 1
+
+
+coro_fun()
+
+
 @context("mock_callable()")
 def mock_callable_tests(context):
 
@@ -100,6 +107,28 @@ def mock_callable_tests(context):
             "This fun is private"
         ).and_assert_called_once()
         t._privatefun()
+
+    @context.example
+    def return_value_raises_with_coroutine(self):
+        with self.assertRaises(ValueError):
+            self.mock_callable(
+                sample_module, "test_function", type_validation=False
+            ).to_return_value(coro_fun())
+
+    @context.example
+    def return_values_raises_with_coroutine(self):
+        with self.assertRaises(ValueError):
+            self.mock_callable(
+                sample_module, "test_function", type_validation=False
+            ).to_return_values([1, 2, coro_fun()])
+
+    @context.example
+    def with_implementation_raises_with_coroutine(self):
+        with self.assertRaises(ValueError):
+            self.mock_callable(
+                sample_module, "test_function", type_validation=False
+            ).with_implementation(coro_fun)
+            sample_module.test_function("a", "b")
 
     ##
     ## Shared Contexts

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -27,6 +27,11 @@ class TypeCheckError(BaseException):
     pass
 
 
+class CoroutineValueError(BaseException):
+    def __init__(self):
+        self.message = "Setting coroutines as return value is not allowed. Use mock_async_callable instead"
+
+
 class WrappedMock(unittest.mock.NonCallableMock):
     """Needed to be able to show the useful qualified name for mock specs"""
 


### PR DESCRIPTION
**What:**
Fail mock_callable calls with to_return(s)/with_implementation pointing to coroutines

**Why:**

#108 

**How:**


**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
