### PR TITLE
Fix template validation

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -431,7 +431,7 @@ def strict_mock(context):
                         @context.example
                         def raises_with_invalid_template(self):
                             with self.assertRaises(ValueError):
-                                StrictMock(Template.instance_method)
+                                StrictMock(dict())
 
                         @context.example
                         def allows_setting_valid_type_with_templated_mock(self):

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -474,7 +474,7 @@ class StrictMock(object):
         to validate that mock attribute types match them. Type validation also
         happens forcallable attributes (instance/static/class methods) calls.
         """
-        if template and not inspect.isclass(template):
+        if template is not None and not inspect.isclass(template):
             raise ValueError("Template must be a class.")
         self.__dict__["_template"] = template
 


### PR DESCRIPTION
We were not raising `ValueError` for bad templates when `bool(template) == False`.