### PR TITLE
fix formatting errors resulting from black update in travis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=["setuptools>=38.6.0"],
-    install_requires=["psutil>=5.6.7", "typeguard>=2.9.1",],
+    install_requires=[
+        "psutil>=5.6.7",
+        "typeguard>=2.9.1",
+    ],
     extras_require={
         "build": [
             "black",

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -243,34 +243,68 @@ def _validate_callable_arg_types(context):
 
             @context.example
             def passes_with_StritMock_without_template(self):
-                self.assert_passes({"StrictMock": ("str", StrictMock(),)})
+                self.assert_passes(
+                    {
+                        "StrictMock": (
+                            "str",
+                            StrictMock(),
+                        )
+                    }
+                )
 
             @context.example("it works with unittest.mock.Mock without spec")
             def passes_with_unittest_mock_Mock_without_spec(self):
-                self.assert_passes({"Mock": ("str", unittest.mock.Mock(),)})
+                self.assert_passes(
+                    {
+                        "Mock": (
+                            "str",
+                            unittest.mock.Mock(),
+                        )
+                    }
+                )
 
             @context.example
             def passes_with_StritMock_with_valid_template(self):
                 self.assert_passes(
-                    {"StrictMock(template=int)": ("str", StrictMock(template=int),)}
+                    {
+                        "StrictMock(template=int)": (
+                            "str",
+                            StrictMock(template=int),
+                        )
+                    }
                 )
 
             @context.example("passes with unittest.mock.Mock with valid spec")
             def passes_with_unittest_mock_Mock_with_valid_spec(self):
                 self.assert_passes(
-                    {"Mock(spec=int)": ("str", unittest.mock.Mock(spec=int),)}
+                    {
+                        "Mock(spec=int)": (
+                            "str",
+                            unittest.mock.Mock(spec=int),
+                        )
+                    }
                 )
 
             @context.example
             def fails_with_StritMock_with_invalid_template(self):
                 self.assert_fails(
-                    {"StrictMock(template=dict)": ("str", StrictMock(template=dict),)}
+                    {
+                        "StrictMock(template=dict)": (
+                            "str",
+                            StrictMock(template=dict),
+                        )
+                    }
                 )
 
             @context.example("fails with unittest.mock.Mock with invalid spec")
             def fails_with_unittest_mock_Mock_with_invalid_spec(self):
                 self.assert_fails(
-                    {"Mock(spec=dict)": ("str", unittest.mock.Mock(spec=dict),)}
+                    {
+                        "Mock(spec=dict)": (
+                            "str",
+                            unittest.mock.Mock(spec=dict),
+                        )
+                    }
                 )
 
 

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -599,19 +599,25 @@ def strict_mock(context):
                                             )
 
                                 @context.sub_context("with type_validation=True")
-                                def with_type_validation_True(context,):
+                                def with_type_validation_True(
+                                    context,
+                                ):
                                     context.merge_context(
-                                        "common examples", type_validation=True,
+                                        "common examples",
+                                        type_validation=True,
                                     )
 
                                 @context.sub_context("with type_validation=False")
-                                def with_type_validation_False(context,):
+                                def with_type_validation_False(
+                                    context,
+                                ):
                                     context.memoize(
                                         "type_validation", lambda self: False
                                     )
 
                                     context.merge_context(
-                                        "common examples", type_validation=False,
+                                        "common examples",
+                                        type_validation=False,
                                     )
 
                                     @context.example
@@ -869,11 +875,14 @@ def strict_mock(context):
                                         return 1234
 
                                     setattr(
-                                        self.strict_mock, self.method_name, mock,
+                                        self.strict_mock,
+                                        self.method_name,
+                                        mock,
                                     )
                                     with self.assertRaises(TypeCheckError):
                                         await getattr(
-                                            self.strict_mock, self.method_name,
+                                            self.strict_mock,
+                                            self.method_name,
                                         )("message")
 
                             else:
@@ -928,29 +937,38 @@ def strict_mock(context):
                                         return 1234
 
                                     setattr(
-                                        self.strict_mock, self.method_name, mock,
+                                        self.strict_mock,
+                                        self.method_name,
+                                        mock,
                                     )
                                     self.assertEqual(
                                         await getattr(
-                                            self.strict_mock, self.method_name,
+                                            self.strict_mock,
+                                            self.method_name,
                                         )("message"),
                                         1234,
                                     )
 
                         @context.sub_context("with type_validation=True")
-                        def with_type_validation_True(context,):
+                        def with_type_validation_True(
+                            context,
+                        ):
                             context.merge_context(
-                                "common examples", type_validation=True,
+                                "common examples",
+                                type_validation=True,
                             )
 
                         @context.sub_context("with type_validation=False")
-                        def with_type_validation_False(context,):
+                        def with_type_validation_False(
+                            context,
+                        ):
                             @context.memoize_before
                             async def type_validation(self):
                                 return False
 
                             context.merge_context(
-                                "common examples", type_validation=False,
+                                "common examples",
+                                type_validation=False,
                             )
 
                             @context.example

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -484,7 +484,12 @@ class _AsyncCallOriginalRunner(_AsyncRunner):
 
 class _CallableMock(object):
     def __init__(
-        self, target, method, caller_frame_info, is_async=False, type_validation=True,
+        self,
+        target,
+        method,
+        caller_frame_info,
+        is_async=False,
+        type_validation=True,
     ):
         self.target = target
         self.method = method

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -211,7 +211,12 @@ def _get_mocked_class(original_class, target_class_id, callable_mock, type_valid
     # ...and reuse them...
     mocked_class_dict = {
         "__new__": _wrap_type_validation(
-            original_class, callable_mock, [original_class_new, original_class_init,]
+            original_class,
+            callable_mock,
+            [
+                original_class_new,
+                original_class_init,
+            ],
         )
         if type_validation
         else callable_mock

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -228,7 +228,10 @@ class FailurePrinterMixin(ColorFormatterMixin):
             exception_list = [exception]
         for number, exception in enumerate(exception_list):
             self.print_red(
-                "    {number}) ".format(number=number + 1,), end="",
+                "    {number}) ".format(
+                    number=number + 1,
+                ),
+                end="",
             )
             self._print_stack_trace(exception, cause_depth=0)
 
@@ -468,7 +471,8 @@ class LongFormatter(DSLDebugMixin, SlowImportWarningMixin, FailurePrinterMixin):
             print("  ", end="")
         self.print_red(
             "{focus}{example}: ".format(
-                focus="*" if example.focus else "", example=example,
+                focus="*" if example.focus else "",
+                example=example,
             ),
             end="",
         )

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -573,11 +573,13 @@ class StrictMock(object):
                     if not callable(value):
                         raise NonCallableValue(self, name)
                     if self.__dict__["_type_validation"]:
-                        signature_validation_wrapper = testslide.lib._wrap_signature_and_type_validation(
-                            value,
-                            self._template,
-                            name,
-                            self.__dict__["_type_validation"],
+                        signature_validation_wrapper = (
+                            testslide.lib._wrap_signature_and_type_validation(
+                                value,
+                                self._template,
+                                name,
+                                self.__dict__["_type_validation"],
+                            )
                         )
 
                         if inspect.iscoroutinefunction(template_value):


### PR DESCRIPTION
<!-- 
Since Black version is not contsrained in setup.py a newer version of black caused travis tests to break on formatting.
This surfaced in #227 and #230  where previous builds passed linting. This fixes it.

-->

**What:**

Reformat code with new release of black, to make build pass again

**Why:**

<!-- Why are these changes necessary? -->

**How:**

* upgrade black to latest version.
* black . 

**Risks:**
None

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
