### PR TITLE
Fix hiding internal stack traces

### DIFF
--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -12,7 +12,14 @@ import unittest
 from typing import List
 from unittest.mock import Mock, call, patch
 
-from testslide import AggregatedExceptions, Context, SlowCallback, _ExampleRunner, reset
+from testslide import (
+    AggregatedExceptions,
+    Context,
+    Example,
+    SlowCallback,
+    _ExampleRunner,
+    reset,
+)
 from testslide.dsl import context, fcontext, xcontext
 from testslide.runner import QuietFormatter
 
@@ -97,8 +104,8 @@ class TestDSLBase(unittest.TestCase):
     def setUp(self):
         reset()
 
-    def run_example(self, exapmle):
-        _ExampleRunner(exapmle, QuietFormatter(import_module_names=__name__)).run()
+    def run_example(self, exapmle: Example) -> None:
+        _ExampleRunner(exapmle, QuietFormatter(import_module_names=[__name__])).run()
 
     def run_all_examples(self):
         for each_context in Context.all_top_level_contexts:

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -98,7 +98,7 @@ class TestDSLBase(unittest.TestCase):
         reset()
 
     def run_example(self, exapmle):
-        _ExampleRunner(exapmle, QuietFormatter()).run()
+        _ExampleRunner(exapmle, QuietFormatter(import_module_names=__name__)).run()
 
     def run_all_examples(self):
         for each_context in Context.all_top_level_contexts:

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -691,7 +691,7 @@ class Context(object):
         return final_list
 
     @property
-    def hierarchy(self):
+    def hierarchy(self) -> List["Context"]:
         """
         Returns a list of all contexts in this hierarchy.
         """

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -369,6 +369,7 @@ class Cli(object):
         else:
             import_secs = self._load_all_examples(config.import_module_names)
             formatter = self.FORMAT_NAME_TO_FORMATTER_CLASS[config.format](
+                import_module_names=config.import_module_names,
                 force_color=config.force_color,
                 import_secs=import_secs,
                 trim_path_prefix=config.trim_path_prefix,

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -354,7 +354,7 @@ class Cli(object):
             ]
         return config
 
-    def run(self):
+    def run(self) -> int:
         try:
             parsed_args = self.parser.parse_args(self.args)
         except SystemExit as e:


### PR DESCRIPTION
This changes the logic behind hiding stack traces to:

- Find the **first** line which is one of the modules being tested.
- Only print from this line forward.

Closes #217.