### PR TITLE
Fix mock callable/constructor to not accept extra configuration after…

### DIFF
--- a/tests/mock_async_callable_testslide.py
+++ b/tests/mock_async_callable_testslide.py
@@ -344,6 +344,18 @@ def mock_async_callable_tests(context):
             ):
                 self.assert_all()
 
+        @context.example
+        async def mock_async_callable_can_not_assert_if_already_received_call(self):
+            mock = self.mock_async_callable(
+                self.target_arg, self.callable_arg
+            ).to_return_value("mocked")
+            await self.callable_target(*self.call_args, **self.call_kwargs)
+            with self.assertRaisesRegex(
+                ValueError,
+                "^No extra configuration is allowed after mock_async_callable.+self.mock_async_callable",
+            ):
+                mock.and_assert_called_once()
+
     @context.shared_context
     def sync_methods_examples(context, not_in_class_instance_method=False):
         @context.sub_context

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
 import contextlib
 import os
 
@@ -449,21 +448,12 @@ def mock_callable_tests(context):
             @context.example
             def mock_callable_can_not_assert_if_already_received_call(self):
                 t = sample_module.SomeClass()
+                mock = self.mock_callable(t, "method").to_return_value("value")
+                t.method()
                 with self.assertRaisesRegex(
-                    ValueError, "^No extra configuration is allowed after mock_callable.+self.mock_callable"
+                    ValueError,
+                    "^No extra configuration is allowed after mock_callable.+self.mock_callable",
                 ):
-                    mock = self.mock_callable(t, "method").to_return_value("value")
-                    t.method()
-                    mock.and_assert_called_once()
-
-            @context.example
-            def mock_async_callable_can_not_assert_if_already_received_call(self):
-                t = sample_module.ParentTarget()
-                with self.assertRaisesRegex(
-                    ValueError, "^No extra configuration is allowed after mock_async_callable.+self.mock_async_callable"
-                ):
-                    mock = self.mock_async_callable(t, "async_instance_method").to_return_value("value")
-                    asyncio.run(t.async_instance_method("", ""))
                     mock.and_assert_called_once()
 
             @context.sub_context(".and_assert_not_called()")

--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
 import contextlib
 import os
 
@@ -444,6 +445,26 @@ def mock_callable_tests(context):
                     ValueError, "^You must first define a behavior.+"
                 ):
                     self.mock_callable_dsl.and_assert_called_exactly(1)
+
+            @context.example
+            def mock_callable_can_not_assert_if_already_received_call(self):
+                t = sample_module.SomeClass()
+                with self.assertRaisesRegex(
+                    ValueError, "^No extra configuration is allowed after mock_callable.+self.mock_callable"
+                ):
+                    mock = self.mock_callable(t, "method").to_return_value("value")
+                    t.method()
+                    mock.and_assert_called_once()
+
+            @context.example
+            def mock_async_callable_can_not_assert_if_already_received_call(self):
+                t = sample_module.ParentTarget()
+                with self.assertRaisesRegex(
+                    ValueError, "^No extra configuration is allowed after mock_async_callable.+self.mock_async_callable"
+                ):
+                    mock = self.mock_async_callable(t, "async_instance_method").to_return_value("value")
+                    asyncio.run(t.async_instance_method("", ""))
+                    mock.and_assert_called_once()
 
             @context.sub_context(".and_assert_not_called()")
             def and_assert_not_called(context):

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -311,6 +311,20 @@ def mock_constructor(context):
             self.assertIsNone(t1)
             self.assertIsNone(t2)
 
+        @context.example
+        def mock_constructor_can_not_assert_if_already_received_call(self):
+            with self.assertRaisesRegex(
+                ValueError, "^No extra configuration is allowed after mock_constructor.+self.mock_constructor"
+            ):
+                mock = self.mock_constructor(self.target_module, self.target_class_name).for_call(
+                    "Hello", "World"
+                ).to_return_value(None)
+
+                target_class = self.get_target_class()
+                t1 = target_class("Hello", "World")
+
+                mock.and_assert_called_once()
+
         @context.sub_context
         def behavior(context):
             @context.example(".to_call_original() works")

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -313,16 +313,17 @@ def mock_constructor(context):
 
         @context.example
         def mock_constructor_can_not_assert_if_already_received_call(self):
+            mock = (
+                self.mock_constructor(self.target_module, self.target_class_name)
+                .for_call("Hello", "World")
+                .to_return_value(None)
+            )
+            target_class = self.get_target_class()
+            target_class("Hello", "World")
             with self.assertRaisesRegex(
-                ValueError, "^No extra configuration is allowed after mock_constructor.+self.mock_constructor"
+                ValueError,
+                "^No extra configuration is allowed after mock_constructor.+self.mock_constructor",
             ):
-                mock = self.mock_constructor(self.target_module, self.target_class_name).for_call(
-                    "Hello", "World"
-                ).to_return_value(None)
-
-                target_class = self.get_target_class()
-                t1 = target_class("Hello", "World")
-
                 mock.and_assert_called_once()
 
         @context.sub_context

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -572,10 +572,11 @@ class _CallableMock(object):
 class _MockCallableDSL(object):
 
     CALLABLE_MOCKS: Dict[int, _CallableMock] = {}
+    _NAME: str = "mock_callable"
 
     def _validate_patch(
         self,
-        name="mock_callable",
+        name=_NAME,
         other_name="mock_async_callable",
         coroutine_function=False,
         callable_returns_coroutine=False,
@@ -770,6 +771,15 @@ class _MockCallableDSL(object):
                 "self.mock_callable(target, 'func')"
                 ".to_return_value(value)"
                 ".and_assert_called_exactly(times)"
+            )
+        if self._runner._call_count > 0:
+            raise ValueError(
+                f"No extra configuration is allowed after {self._NAME} "
+                f"receives its first call, it received {self._runner._call_count} "
+                f"call{'s' if self._runner._call_count > 1 else ''} already. "
+                "You should instead define it all at once, "
+                f"eg: self.{self._NAME}(target, 'func')"
+                ".to_return_value(value).and_assert_called_once()"
             )
 
     ##
@@ -1005,6 +1015,9 @@ class _MockCallableDSL(object):
 
 
 class _MockAsyncCallableDSL(_MockCallableDSL):
+
+    _NAME: str = "mock_async_callable"
+
     def __init__(
         self,
         target,
@@ -1026,7 +1039,7 @@ class _MockAsyncCallableDSL(_MockCallableDSL):
 
     def _validate_patch(self):
         return super()._validate_patch(
-            name="mock_async_callable",
+            name=self._NAME,
             other_name="mock_callable",
             coroutine_function=True,
             callable_returns_coroutine=self._callable_returns_coroutine,

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -63,6 +63,8 @@ class _MockConstructorDSL(_MockCallableDSL):
     Specialized version of _MockCallableDSL to call __new__ with correct args
     """
 
+    _NAME: str = "mock_constructor"
+
     def __init__(self, target, method, cls, callable_mock=None, original_callable=None):
         self.cls = cls
         caller_frame = inspect.currentframe().f_back


### PR DESCRIPTION
**What:**

This fixes [issue 16](https://github.com/facebookincubator/TestSlide/issues/16), not allowing that extra configuration is made after `mock_callable`, `mock_async_callable` or mock_constructor` receive their first call.

Added tests to cover the constraint to not allow extra configuration to be made in `mock_callable`, `mock_async_callable` and `mock_constructor` and also validated with ad-hoc tests that *TestSlide* tests continues to behave as expected. As show below:

For the ad-hoc tests I used this [test_extra_configuration.py](https://gist.github.com/ldfsilva/b4b6b7964ef9cda7819059569997efbb) and invoked tests as follows:

```
python -m unittest -v tests.test_extra_configuration
```

Here are excerpts from the test results: [[here](https://gist.github.com/ldfsilva/d88ff7e16964080d16e59b2510da21fc)]

**mock_async_calable:**
```
ERROR: test_mock_async_callable_fail_already_received_1_call (tests.test_extra_configuration.TestCase)
ValueError: No extra configuration is allowed after mock_async_callable receives its first call, it received 1 call already. You should instead define it all at once, eg: self.mock_async_callable(target, 'func').to_return_value(value).and_assert_called_once()
```

```
ERROR: test_mock_async_callable_fail_already_received_8_calls (tests.test_extra_configuration.TestCase)
ValueError: No extra configuration is allowed after mock_async_callable receives its first call, it received 8 calls already. You should instead define it all at once, eg: self.mock_async_callable(target, 'func').to_return_value(value).and_assert_called_once()
```

**mock_calable:**

```
ERROR: test_mock_callable_fail_already_received_1_call (tests.test_extra_configuration.TestCase)
ValueError: No extra configuration is allowed after mock_callable receives its first call, it received 1 call already. You should instead define it all at once, eg: self.mock_callable(target, 'func').to_return_value(value).and_assert_called_once()
```

```
ERROR: test_mock_callable_fail_already_received_8_calls (tests.test_extra_configuration.TestCase)
ValueError: No extra configuration is allowed after mock_callable receives its first call, it received 8 calls already. You should instead define it all at once, eg: self.mock_callable(target, 'func').to_return_value(value).and_assert_called_once()
```

**mock_constructor:**
```
ERROR: test_mock_constructor_fail_already_received_1_call (tests.test_extra_configuration.TestCase)
ValueError: No extra configuration is allowed after mock_constructor receives its first call, it received 1 call already. You should instead define it all at once, eg: self.mock_constructor(target, 'func').to_return_value(value).and_assert_called_once()
```

```
ERROR: test_mock_constructor_fail_already_received_8_calls (tests.test_extra_configuration.TestCase)
ValueError: No extra configuration is allowed after mock_constructor receives its first call, it received 8 calls already. You should instead define it all at once, eg: self.mock_constructor(target, 'func').to_return_value(value).and_assert_called_once()
```