### PR TITLE
Detect leaked tasks

### DIFF
--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -43,7 +43,7 @@ like this:
       assert self.memoize_before == "memoize_before"
       assert self.function == "function"
 
-The test runner will create a new event look to execute each example.
+The test runner will create a new event loop to execute each example.
 
 .. note::
 
@@ -184,3 +184,36 @@ Python's default threshold for triggering this event loop lock up failure is **1
 
   Finished 1 example(s) in 1.0s
     Successful: 1
+
+Leaked Tasks
+^^^^^^^^^^^^
+
+If your async code creates a task in the asyncio loop, but finished before that task has ended (ex. you forgot to await for it), testslide will catch it and fail the test.
+
+This is enabled by default for async tests, but to get that behaviour also when running async code from sync tests, for example:
+
+
+.. code-block:: python
+
+  import asyncio
+  from testslide.dsl import context
+
+  @context
+  def my_test_suite(context):
+        @context.example
+        def test_something_async(self):
+            asyncio.run(my_async_function())
+
+
+Has to use the `async_run` function from the context, so instead, you should use:
+
+.. code-block:: python
+
+  import asyncio
+  from testslide.dsl import context
+
+  @context
+  def my_test_suite(context):
+        @context.example
+        def test_something_async(self):
+            self.async_run(my_async_function())

--- a/docs/testslide_dsl/async_support/index.rst
+++ b/docs/testslide_dsl/async_support/index.rst
@@ -205,7 +205,7 @@ This is enabled by default for async tests, but to get that behaviour also when 
             asyncio.run(my_async_function())
 
 
-Has to use the `async_run` function from the context, so instead, you should use:
+Has to use the `async_run_with_health_checks` function from the context, so instead, you should use:
 
 .. code-block:: python
 
@@ -216,4 +216,4 @@ Has to use the `async_run` function from the context, so instead, you should use
   def my_test_suite(context):
         @context.example
         def test_something_async(self):
-            self.async_run(my_async_function())
+            self.async_run_with_health_checks(my_async_function())

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -2040,10 +2040,11 @@ class TestMockAsyncCallableIntegration(TestDSLBase):
         def fail_top(context):
             @context.example
             async def spawn_task_but_dont_await(self):
-                # once we stop supporting python 3.6 we can use
-                # asyncio.create_task instead
-                loop = asyncio.get_event_loop()
-                loop.create_task(dummy_async_func())
+                if sys.version_info < (3, 7):
+                    loop = asyncio.get_event_loop()
+                    loop.create_task(dummy_async_func())
+                else:
+                    asyncio.create_task(dummy_async_func())
 
         examples = _get_name_to_examples()
 
@@ -2088,10 +2089,11 @@ class TestAsyncRun(TestDSLBase):
             pass
 
         async def spawn_task_but_dont_await():
-            # once we stop supporting python 3.6 we can use
-            # asyncio.create_task instead
-            loop = asyncio.get_event_loop()
-            loop.create_task(dummy_async_func())
+            if sys.version_info < (3, 7):
+                loop = asyncio.get_event_loop()
+                loop.create_task(dummy_async_func())
+            else:
+                asyncio.create_task(dummy_async_func())
 
         @context
         def fail_top(context):

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -1621,7 +1621,7 @@ class TestExample(TestDSLBase):
 
     def test_inherits_skip_from_xcontext(self):
         """
-        Exmaples inherit skip setting from parent context.
+        Examples inherit skip setting from parent context.
         """
 
         @xcontext
@@ -1647,7 +1647,7 @@ class TestExample(TestDSLBase):
 
     def test_inherits_focus_from_fcontext(self):
         """
-        Exmaples inherit focus setting from parent context.
+        Examples inherit focus setting from parent context.
         """
 
         @fcontext

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -2081,37 +2081,6 @@ class TestMockConstructorIntegration(TestDSLBase):
             self.run_example(examples["expect fail"])
 
 
-class TestMock(TestDSLBase):
-    def test_mock_constructor_integration(self):
-        @context
-        def fail_top(context):
-            @context.sub_context
-            def fail_sub_context(context):
-                @context.example
-                def expect_fail(self):
-                    self.mock_constructor("subprocess", "Popen").for_call(
-                        ["cmd"]
-                    ).to_return_value("mocked_popen").and_assert_called_once()
-
-        @context
-        def pass_top(context):
-            @context.sub_context
-            def pass_sub_context(context):
-                @context.example
-                def expect_pass(self):
-                    self.mock_constructor("subprocess", "Popen").for_call(
-                        ["cmd"]
-                    ).to_return_value("mocked_popen").and_assert_called_once()
-                    assert subprocess.Popen(["cmd"]) == "mocked_popen"
-
-        examples = _get_name_to_examples()
-
-        self.run_example(examples["expect pass"])
-
-        with self.assertRaisesRegex(AssertionError, "calls did not match assertion"):
-            self.run_example(examples["expect fail"])
-
-
 class TestAsyncRun(TestDSLBase):
     def test_catches_leaked_tasks(self):
         async def dummy_async_func():

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -16,6 +16,7 @@ from testslide import (
     AggregatedExceptions,
     Context,
     Example,
+    LeftOverActiveTasks,
     SlowCallback,
     _ExampleRunner,
     reset,
@@ -2046,7 +2047,7 @@ class TestMockAsyncCallableIntegration(TestDSLBase):
 
         examples = _get_name_to_examples()
 
-        with self.assertRaisesRegex(RuntimeError, "Some tasks were started"):
+        with self.assertRaisesRegex(LeftOverActiveTasks, "Some tasks were started"):
             self.run_example(examples["spawn task but dont await"])
 
 
@@ -2100,5 +2101,5 @@ class TestAsyncRun(TestDSLBase):
 
         examples = _get_name_to_examples()
 
-        with self.assertRaisesRegex(RuntimeError, "Some tasks were started"):
+        with self.assertRaisesRegex(LeftOverActiveTasks, "Some tasks were started"):
             self.run_example(examples["raise on leaked task"])

--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -2127,7 +2127,7 @@ class TestAsyncRun(TestDSLBase):
         def fail_top(context):
             @context.example
             def raise_on_leaked_task(self):
-                self.async_run(spawn_task_but_dont_await())
+                self.async_run_with_health_checks(spawn_task_but_dont_await())
 
         examples = _get_name_to_examples()
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -230,7 +230,7 @@ class _ContextData(object):
         with self._sub_examples_agg_ex.catch():
             yield
 
-    def async_run(self, coro):
+    def async_run_with_health_checks(self, coro):
         """
         Runs the given coroutine in a new event loop, and ensuring there's no
         task leakage.

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -72,6 +72,12 @@ else:
     get_all_tasks = asyncio.all_tasks
 
 
+class LeftOverActiveTasks(BaseException):
+    """Risen when unfinished asynchronous tasks are detected."""
+
+    pass
+
+
 def _importer(target: str) -> Any:
     components = target.split(".")
     import_path = components.pop(0)
@@ -97,7 +103,7 @@ async def _async_ensure_no_leaked_tasks(coro):
     new_still_running_tasks = set(after_example_tasks) - set(before_example_tasks)
     if new_still_running_tasks:
         tasks_str = "\n".join(str(task) for task in new_still_running_tasks)
-        raise RuntimeError(
+        raise LeftOverActiveTasks(
             "Some tasks were started but did not finish yet, are you missing "
             f"an `await` somewhere?\nRunning tasks:\n {tasks_str}"
         )


### PR DESCRIPTION
**What:**

Add leaked tasks detection to both sync and async tests.
Fixes #244

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->

**Why:**

If you were to start a task (ex. using asyncio.create_task) and not await for it, there would be no indication that the task was finished (or not) before the test ended.

<!-- Why are these changes necessary? -->

**How:**

Wrap the execution of the test (the async block of code specifically) and check the tasks that were running before and after, and if there's any new task running after then throw an exception.

<!-- How were these changes implemented? -->

**Risks:**

Tests were not checking this issue before, so any test that before might have been leaking tasks, will not start failing.

<!-- Any possible risks you've likely introduced in this PR?  -->

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->