### PR TITLE
Hide all TestSlide internal paths

### DIFF
--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -6,6 +6,7 @@
 import inspect
 import io
 import os
+import os.path
 import random
 import sys
 import time
@@ -18,6 +19,8 @@ import psutil
 import pygments
 import pygments.formatters
 import pygments.lexers
+
+import testslide
 
 from . import AggregatedExceptions, Context, Example, Skip, _ExampleRunner
 
@@ -199,6 +202,8 @@ class ColorFormatterMixin(BaseFormatter):
 
 
 class FailurePrinterMixin(ColorFormatterMixin):
+    TESTSLIDE_PATH = os.path.abspath(os.path.dirname(testslide.__file__))
+
     def _get_test_module_index(self, tb: traceback.StackSummary) -> int:
         test_module_index = len(tb) - 1
 
@@ -232,8 +237,11 @@ class FailurePrinterMixin(ColorFormatterMixin):
         test_module_index = self._get_test_module_index(tb)
 
         for index, (path, line, function_name, text) in enumerate(tb):
-            if not self.show_testslide_stack_trace and index < test_module_index:
-                continue
+            if not self.show_testslide_stack_trace:
+                if index < test_module_index:
+                    continue
+                if os.path.abspath(path).startswith(self.TESTSLIDE_PATH):
+                    continue
             if self.trim_path_prefix:
                 split = path.split(self.trim_path_prefix)
                 if len(split) == 2 and not split[0]:


### PR DESCRIPTION
Given:

```
import testslide

async def mock():
    pass

class Repro(testslide.TestCase):
    def test_repro(self):
        self.mock_callable("time", "time").to_return_value(mock())
```

We currently get:

```
$ python -m testslide.cli repro.py 
repro.Repro
  test_repro: CoroutineValueError: 

Failures:

  1) repro.Repro: test_repro
    1) CoroutineValueError: 
      File "repro.py", line 9, in test_repro
        self.mock_callable("time", "time").to_return_value(mock())
      File "testslide/mock_callable.py", line 875, in to_return_value
        _ReturnValueRunner(
      File "testslide/mock_callable.py", line 399, in __init__
        raise CoroutineValueError()

Finished 1 example(s) in 1.2s 
  Failed: 1
```

From #217 , we're starting to print the paths once we find the **first** test module path. In some cases (as in this example), paths internal to TestSlide are still printed.

This PR adds another rule on top of the rule from #217 to exclude **all** paths that are internal to TestSlide itself as those should only be useful for TestSlide development:

```
repro.Repro
  test_repro: CoroutineValueError: 

Failures:

  1) repro.Repro: test_repro
    1) CoroutineValueError: 
      File "repro.py", line 9, in test_repro
        self.mock_callable("time", "time").to_return_value(mock())

Finished 1 example(s) in 1.2s 
  Failed: 1
```

Also moved some tests that should be common to all formatters to the mixin class.