### PR TITLE
Expose PEP-561 typing information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
         "typeguard>=2.10.0",
         'dataclasses==0.6; python_version < "3.7"',
     ],
+    package_data={
+        'testslide': ['py.typed'],
+    },
     extras_require={
         "build": [
             "black",


### PR DESCRIPTION
<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

**What:**
Expose PEP-561 typing information

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->

**Why:**
<!-- Why are these changes necessary? -->
The typing is exposed via [PEP-561](https://www.python.org/dev/peps/pep-0561/)
Doing so ensures that dependencies of the library will benefit of the typing annotations provided by the library without requiring the definition of custom typesheds

**How:**
<!-- How were these changes implemented? -->
Add `py.typed` file as described in https://www.python.org/dev/peps/pep-0561/#packaging-type-information

**Risks:**
<!-- Any possible risks you've likely introduced in this PR?  -->
Users of the library might start to get some typing issues, but this reports (assuming that the types in the library are correct) represent issues on users-code's typing

**Checklist**:
<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->
- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
