### PR TITLE
testslide: remove unnecessary shebangs

### DIFF
--- a/testslide/import_profiler.py
+++ b/testslide/import_profiler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the


### PR DESCRIPTION
These aren't needed, and ended up getting flagged when packaging TestSlide for Fedora in https://bugzilla.redhat.com/show_bug.cgi?id=1891963