### PR TITLE
util: use python3 for run_silent_if_successful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DIST_TAR_GZ = dist/TestSlide-$(shell cat testslide/version).tar.gz
 # Verbose output: make V=1
 V?=0
 ifeq ($(V),0)
-Q := @python util/run_silent_if_successful.py
+Q := @python3 util/run_silent_if_successful.py
 else
 Q :=
 endif

--- a/util/run_silent_if_successful.py
+++ b/util/run_silent_if_successful.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) Facebook, Inc. and its affiliates.
 #


### PR DESCRIPTION
TestSlide requires Python 3, so might as well use it here too. This fixes the build on systems that don't have Python 2 installed as `/usr/bin/python`, such as modern Fedora and CentOS.