### PR TITLE
downgrade pygments requirement to 2.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     setup_requires=["setuptools>=38.6.0"],
     install_requires=[
         "psutil>=5.6.7",
-        "Pygments>=2.7.1",
+        "Pygments>=2.6.1",
         "typeguard>=2.10.0",
         'dataclasses==0.6; python_version < "3.7"',
     ],


### PR DESCRIPTION
Unless I'm mistaken, we don't actually _need_ 2.7.1 for this, and downgrading the requirement to 2.6.1 makes it possible to get TestSlide packaged in Fedora 33.