### PR TITLE
Skip finished tasks when checking for async leaked tasks

### DIFF
--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -72,6 +72,10 @@ else:
     get_all_tasks = asyncio.all_tasks
 
 
+def get_running_tasks():
+    return [task for task in get_all_tasks() if not task.done()]
+
+
 class LeftOverActiveTasks(BaseException):
     """Risen when unfinished asynchronous tasks are detected."""
 
@@ -97,9 +101,9 @@ def _importer(target: str) -> Any:
 
 
 async def _async_ensure_no_leaked_tasks(coro):
-    before_example_tasks = get_all_tasks()
+    before_example_tasks = get_running_tasks()
     result = await coro
-    after_example_tasks = get_all_tasks()
+    after_example_tasks = get_running_tasks()
     new_still_running_tasks = set(after_example_tasks) - set(before_example_tasks)
     if new_still_running_tasks:
         tasks_str = "\n".join(str(task) for task in new_still_running_tasks)


### PR DESCRIPTION
**What:**
Updated leaked tasks checking to skip finished coroutines, in order to avoid incorrect failures when tasks have been completed

**Why:**
With Python versions that doesnt include this fix (https://github.com/python/cpython/pull/7174), Testslide will raise a LeftOverActiveTasks exception even if all coroutines have been completed successfully.
Example:
` <Task finished coro=<TestAsyncRun.test_catches_leaked_tasks.<locals>.dummy_async_func() done, defined at *> result=None created at *>`

Although the task is **done**, Testslide will **fail**.

This PR skips finished tasks from the async leak testing

**How:**

- Added extra function get_running_tasks to return only non done tasks
- Updated _async_ensure_no_leaked_tasks to use this new function

**Checklist**:

- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")
