### PR TITLE
move dependency management to requirements.txt and requirements-dev.txt.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# set base image (host OS)
+FROM python:3.8
+
+# set the working directory in the container
+WORKDIR /code
+
+# install make 
+RUN apt-get update && apt-get install -y \
+  make \
+  && rm -rf /var/lib/apt/lists/*
+# copy the dependencies file to the working directory
+COPY requirements.txt .
+# copy the dev-dependencies file to the working directory
+
+COPY requirements-dev.txt .
+
+# install dependencies
+RUN pip install -r requirements.txt
+# install dev dependencies
+RUN pip install -r requirements-dev.txt
+
+
+# copy the source to container working directory
+COPY testslide ./testslide
+COPY tests ./tests
+COPY util ./util
+COPY Makefile .
+COPY mypy.ini .
+
+# command to run on container start
+CMD ["/usr/bin/make", "tests"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include CONTRIBUTING.md
 include LICENSE 
 include README.md
 include testslide/version
+include requirements.txt
+include requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+black
+coverage
+coveralls
+flake8
+isort~=5.1
+mypy==0.782
+ipython
+sphinx
+sphinx-autobuild
+sphinx-kr-theme
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+psutil>=5.6.7
+Pygments>=2.6.1
+typeguard>=2.10.0
+dataclasses==0.6; python_version < "3.7"

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ from setuptools import setup
 
 version = open("testslide/version").read().rstrip()
 readme = open("README.md", encoding="utf8").read()
+requirements = open("requirements.txt", encoding="utf8").readlines()
+requirements_build = open("requirements-dev.txt", encoding="utf8").readlines()
 
 setup(
     name="TestSlide",
@@ -20,29 +22,12 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=["setuptools>=38.6.0"],
-    install_requires=[
-        "psutil>=5.6.7",
-        "Pygments>=2.6.1",
-        "typeguard>=2.10.0",
-        'dataclasses==0.6; python_version < "3.7"',
-    ],
+    install_requires=requirements,
     package_data={
         'testslide': ['py.typed'],
     },
     extras_require={
-        "build": [
-            "black",
-            "coverage",
-            "coveralls",
-            "flake8",
-            "isort~=5.1",
-            "mypy==0.782",
-            "ipython",
-            "sphinx",
-            "sphinx-autobuild",
-            "sphinx-kr-theme",
-            "twine",
-        ]
+        "build": requirements_build
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Add dockerfile and Docker related make targets



**What:**

- Move dependency management to requirements.txt and requirements-dev.txt to ease local development 
- Add related make targets: make install_build_deps and make install_deps
- Add Dockerfile 
- Add Docker related make targets to build, one-shot test built image, run container with bind-mounted sources in the background, enter said container:
Sample Docker run: https://gist.github.com/deathowl/e30bb72a791e362b3a8cf0e45e56c4f3
**Why:**

To ease development :) 
**How:**

**Risks:**
None
**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [X] Added tests, if you've added code that should be tested
- [X] Updated the documentation, if you've changed APIs
- [X] Ensured the test suite passes
- [X] Made sure your code lints
- [X] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
