### PR TITLE
requirements: relax dataclasses version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 psutil>=5.6.7
 Pygments>=2.6.1
 typeguard>=2.10.0
-dataclasses==0.6; python_version < "3.7"
+dataclasses>=0.6; python_version < "3.7"


### PR DESCRIPTION
I don't see anything in TestSlide that would require 0.6 specifically, and this will make it easier to get TestSlide packaged for distributions still stuck on Python 3.6 (like EPEL, where I'm in the process of adding dataclasses 0.8 in https://bugzilla.redhat.com/show_bug.cgi?id=1912143).