### PR TITLE
requirements: allow Pygments 2.2.0 or later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 psutil>=5.6.7
-Pygments>=2.6.1
+Pygments>=2.2.0
 typeguard>=2.10.0
 dataclasses>=0.6; python_version < "3.7"


### PR DESCRIPTION
Trying to get TestSlide to build for EPEL in https://bugzilla.redhat.com/show_bug.cgi?id=1912139 and one issue is that RHEL 8 / CentOS 8 only ships with Pygments 2.2.0. I *think* it should work just fine, as I don't see anything in the changelog between 2.2.0 and 2.6.1 that would affect TestSlide directly.